### PR TITLE
refactor(data): harden source contracts, sparse enrichment, and examples

### DIFF
--- a/examples/data_sources/fetch_alpaca_data.py
+++ b/examples/data_sources/fetch_alpaca_data.py
@@ -15,6 +15,7 @@ Note: This example excludes live/streaming data.
 
 from dotenv import load_dotenv
 
+from quantrl_lab.data.exceptions import DataSourceError
 from quantrl_lab.data.sources import AlpacaDataLoader
 
 # Load environment variables from .env file
@@ -36,107 +37,107 @@ def main():
     print("Alpaca Data Examples")
     print("=" * 60)
 
+    def run_example_step(title, fn):
+        print(f"\n{title}")
+        print("-" * 40)
+        try:
+            fn()
+        except DataSourceError as exc:
+            print(f"Skipped: {exc}")
+        except Exception as exc:
+            print(f"Skipped: {exc}")
+
     # ------------------------------------------------------------------
     # Example 1: Fetch historical OHLCV data
     # ------------------------------------------------------------------
-    print("\n[1] Historical OHLCV Data")
-    print("-" * 40)
+    def example_daily():
+        df = loader.get_historical_ohlcv_data(
+            symbols="AAPL",
+            start="2024-01-01",
+            end="2024-03-01",
+            timeframe="1d",
+        )
+        print(f"Retrieved {len(df)} daily bars for AAPL")
+        print(df.head())
 
-    df = loader.get_historical_ohlcv_data(
-        symbols="AAPL",
-        start="2024-01-01",
-        end="2024-03-01",
-        timeframe="1d",  # Daily bars
-    )
-    print(f"Retrieved {len(df)} daily bars for AAPL")
-    print(df.head())
+    run_example_step("[1] Historical OHLCV Data", example_daily)
 
     # ------------------------------------------------------------------
     # Example 2: Fetch data for multiple symbols
     # ------------------------------------------------------------------
-    print("\n[2] Multiple Symbols")
-    print("-" * 40)
+    def example_multi():
+        df_multi = loader.get_historical_ohlcv_data(
+            symbols=["AAPL", "GOOGL", "TSLA"],
+            start="2024-01-01",
+            end="2024-02-01",
+            timeframe="1d",
+        )
+        print(f"Retrieved {len(df_multi)} total bars")
+        print(f"Symbols: {df_multi['Symbol'].unique().tolist()}")
 
-    df_multi = loader.get_historical_ohlcv_data(
-        symbols=["AAPL", "GOOGL", "TSLA"],
-        start="2024-01-01",
-        end="2024-02-01",
-        timeframe="1d",
-    )
-    print(f"Retrieved {len(df_multi)} total bars")
-    print(f"Symbols: {df_multi['Symbol'].unique().tolist()}")
+    run_example_step("[2] Multiple Symbols", example_multi)
 
     # ------------------------------------------------------------------
     # Example 3: Fetch hourly data
     # ------------------------------------------------------------------
-    print("\n[3] Hourly Data")
-    print("-" * 40)
+    def example_hourly():
+        df_hourly = loader.get_historical_ohlcv_data(
+            symbols="NVDA",
+            start="2024-01-15",
+            end="2024-01-20",
+            timeframe="1h",
+        )
+        print(f"Retrieved {len(df_hourly)} hourly bars for NVDA")
+        print(df_hourly.head())
 
-    df_hourly = loader.get_historical_ohlcv_data(
-        symbols="NVDA",
-        start="2024-01-15",
-        end="2024-01-20",
-        timeframe="1h",  # Hourly bars
-    )
-    print(f"Retrieved {len(df_hourly)} hourly bars for NVDA")
-    print(df_hourly.head())
+    run_example_step("[3] Hourly Data", example_hourly)
 
     # ------------------------------------------------------------------
     # Example 4: Get latest quote
     # ------------------------------------------------------------------
-    print("\n[4] Latest Quote")
-    print("-" * 40)
-
-    quote = loader.get_latest_quote("AAPL")
-    print(f"Latest quote for AAPL: {quote}")
+    run_example_step("[4] Latest Quote", lambda: print(f"Latest quote for AAPL: {loader.get_latest_quote('AAPL')}"))
 
     # ------------------------------------------------------------------
     # Example 5: Get latest trade
     # ------------------------------------------------------------------
-    print("\n[5] Latest Trade")
-    print("-" * 40)
-
-    trade = loader.get_latest_trade("AAPL")
-    print(f"Latest trade for AAPL: {trade}")
+    run_example_step("[5] Latest Trade", lambda: print(f"Latest trade for AAPL: {loader.get_latest_trade('AAPL')}"))
 
     # ------------------------------------------------------------------
     # Example 6: Fetch news data
     # ------------------------------------------------------------------
-    print("\n[6] News Data")
-    print("-" * 40)
+    def example_news():
+        news_df = loader.get_news_data(
+            symbols="AAPL",
+            start="2024-01-01",
+            end="2024-01-15",
+            limit=10,
+            include_content=False,
+        )
+        if not news_df.empty:
+            print(f"Retrieved {len(news_df)} news articles")
+            print("\nSample headlines:")
+            for _, row in news_df.head(3).iterrows():
+                print(f"  - {row['headline'][:80]}...")
+        else:
+            print("No news articles found for the specified period.")
 
-    news_df = loader.get_news_data(
-        symbols="AAPL",
-        start="2024-01-01",
-        end="2024-01-15",
-        limit=10,
-        include_content=False,  # Set True to include full article content
-    )
-
-    if not news_df.empty:
-        print(f"Retrieved {len(news_df)} news articles")
-        print("\nSample headlines:")
-        for _, row in news_df.head(3).iterrows():
-            print(f"  - {row['headline'][:80]}...")
-    else:
-        print("No news articles found for the specified period.")
+    run_example_step("[6] News Data", example_news)
 
     # ------------------------------------------------------------------
     # Example 7: News for multiple symbols
     # ------------------------------------------------------------------
-    print("\n[7] News for Multiple Symbols")
-    print("-" * 40)
+    def example_multi_news():
+        news_multi = loader.get_news_data(
+            symbols=["AAPL", "TSLA", "NVDA"],
+            start="2024-01-01",
+            end="2024-01-10",
+            limit=20,
+        )
+        if not news_multi.empty:
+            print(f"Retrieved {len(news_multi)} news articles")
+            print(f"Columns: {news_multi.columns.tolist()}")
 
-    news_multi = loader.get_news_data(
-        symbols=["AAPL", "TSLA", "NVDA"],
-        start="2024-01-01",
-        end="2024-01-10",
-        limit=20,
-    )
-
-    if not news_multi.empty:
-        print(f"Retrieved {len(news_multi)} news articles")
-        print(f"Columns: {news_multi.columns.tolist()}")
+    run_example_step("[7] News for Multiple Symbols", example_multi_news)
 
     print("\n" + "=" * 60)
     print("Examples completed!")

--- a/examples/data_sources/fetch_alphavantage_data.py
+++ b/examples/data_sources/fetch_alphavantage_data.py
@@ -21,6 +21,7 @@ Note: Free tier limitations:
 from dotenv import load_dotenv
 
 from quantrl_lab.data.config import FundamentalMetric, MacroIndicator
+from quantrl_lab.data.exceptions import DataSourceError
 from quantrl_lab.data.sources import AlphaVantageDataLoader
 
 # Load environment variables from .env file
@@ -40,182 +41,183 @@ def main():
     print("Alpha Vantage Data Examples")
     print("=" * 60)
 
+    def run_example_step(title, fn):
+        print(f"\n{title}")
+        print("-" * 40)
+        try:
+            fn()
+        except DataSourceError as exc:
+            print(f"Skipped: {exc}")
+
     # ------------------------------------------------------------------
     # Example 1: Fetch daily OHLCV data (recent, free tier compatible)
     # ------------------------------------------------------------------
-    print("\n[1] Daily OHLCV Data (last 100 trading days)")
-    print("-" * 40)
+    def example_daily_ohlcv():
+        df = loader.get_historical_ohlcv_data(
+            symbols="AAPL",
+            timeframe="1d",
+        )
+        if not df.empty:
+            print(f"Retrieved {len(df)} daily bars for AAPL")
+            print(df.head())
 
-    # Free tier: outputsize='compact' returns last 100 data points
-    # Premium tier: use outputsize='full' for 20+ years of data
-    df = loader.get_historical_ohlcv_data(
-        symbols="AAPL",
-        timeframe="1d",
-        # Note: Don't specify start/end dates with free tier, as outputsize='compact'
-        # only returns the most recent 100 trading days
-    )
-    if not df.empty:
-        print(f"Retrieved {len(df)} daily bars for AAPL")
-        print(df.head())
+    run_example_step("[1] Daily OHLCV Data (last 100 trading days)", example_daily_ohlcv)
 
     # ------------------------------------------------------------------
     # Example 2: Fetch intraday data (PREMIUM FEATURE)
     # ------------------------------------------------------------------
-    print("\n[2] Intraday Data (5-minute bars) - REQUIRES PREMIUM")
-    print("-" * 40)
+    def example_intraday():
+        df_intraday = loader.get_historical_ohlcv_data(
+            symbols="AAPL",
+            timeframe="5min",
+        )
+        if not df_intraday.empty:
+            print(f"Retrieved {len(df_intraday)} intraday bars")
+            print(df_intraday.head())
+        else:
+            print("No intraday data retrieved (may require premium API key)")
 
-    # Note: Historical intraday with 'month' parameter requires premium API key
-    # Free tier only gets recent intraday data (last 1-2 trading days)
-    df_intraday = loader.get_historical_ohlcv_data(
-        symbols="AAPL",
-        timeframe="5min",
-        # month="2024-01",  # Premium feature: historical month data
-    )
-    if not df_intraday.empty:
-        print(f"Retrieved {len(df_intraday)} intraday bars")
-        print(df_intraday.head())
-    else:
-        print("No intraday data retrieved (may require premium API key)")
+    run_example_step("[2] Intraday Data (5-minute bars) - REQUIRES PREMIUM", example_intraday)
 
     # ------------------------------------------------------------------
     # Example 3: Company overview (fundamental data)
     # ------------------------------------------------------------------
-    print("\n[3] Company Overview")
-    print("-" * 40)
+    def example_company_overview():
+        fundamentals = loader.get_fundamental_data(
+            symbol="AAPL",
+            metrics=[FundamentalMetric.COMPANY_OVERVIEW],
+        )
 
-    fundamentals = loader.get_fundamental_data(
-        symbol="AAPL",
-        metrics=[FundamentalMetric.COMPANY_OVERVIEW],
-    )
+        if fundamentals.get("company_overview"):
+            overview = fundamentals["company_overview"]
+            print(f"Company: {overview.get('Name')}")
+            print(f"Sector: {overview.get('Sector')}")
+            print(f"Industry: {overview.get('Industry')}")
+            print(f"Market Cap: {overview.get('MarketCapitalization')}")
+            print(f"PE Ratio: {overview.get('PERatio')}")
 
-    if fundamentals.get("company_overview"):
-        overview = fundamentals["company_overview"]
-        print(f"Company: {overview.get('Name')}")
-        print(f"Sector: {overview.get('Sector')}")
-        print(f"Industry: {overview.get('Industry')}")
-        print(f"Market Cap: {overview.get('MarketCapitalization')}")
-        print(f"PE Ratio: {overview.get('PERatio')}")
+    run_example_step("[3] Company Overview", example_company_overview)
 
     # ------------------------------------------------------------------
     # Example 4: Financial statements
     # ------------------------------------------------------------------
-    print("\n[4] Financial Statements")
-    print("-" * 40)
+    def example_financials():
+        financials = loader.get_fundamental_data(
+            symbol="MSFT",
+            metrics=[
+                FundamentalMetric.INCOME_STATEMENT,
+                FundamentalMetric.BALANCE_SHEET,
+                FundamentalMetric.CASH_FLOW,
+            ],
+        )
 
-    financials = loader.get_fundamental_data(
-        symbol="MSFT",
-        metrics=[
-            FundamentalMetric.INCOME_STATEMENT,
-            FundamentalMetric.BALANCE_SHEET,
-            FundamentalMetric.CASH_FLOW,
-        ],
-    )
+        for metric, data in financials.items():
+            if data:
+                print(f"  {metric}: Retrieved successfully")
 
-    for metric, data in financials.items():
-        if data:
-            print(f"  {metric}: Retrieved successfully")
+    run_example_step("[4] Financial Statements", example_financials)
 
     # ------------------------------------------------------------------
     # Example 5: Earnings data
     # ------------------------------------------------------------------
-    print("\n[5] Earnings Data")
-    print("-" * 40)
+    def example_earnings():
+        earnings = loader.get_fundamental_data(
+            symbol="GOOGL",
+            metrics=[FundamentalMetric.EARNINGS],
+        )
 
-    earnings = loader.get_fundamental_data(
-        symbol="GOOGL",
-        metrics=[FundamentalMetric.EARNINGS],
-    )
+        if earnings.get("earnings"):
+            earnings_data = earnings["earnings"]
+            if "quarterlyEarnings" in earnings_data:
+                print(f"Retrieved {len(earnings_data['quarterlyEarnings'])} quarterly earnings reports")
 
-    if earnings.get("earnings"):
-        earnings_data = earnings["earnings"]
-        if "quarterlyEarnings" in earnings_data:
-            print(f"Retrieved {len(earnings_data['quarterlyEarnings'])} quarterly earnings reports")
+    run_example_step("[5] Earnings Data", example_earnings)
 
     # ------------------------------------------------------------------
     # Example 6: News sentiment data
     # ------------------------------------------------------------------
-    print("\n[6] News Sentiment Data")
-    print("-" * 40)
+    def example_news():
+        news_df = loader.get_news_data(
+            symbols="AAPL",
+            start="2024-01-01",
+            end="2024-01-15",
+            limit=10,
+        )
 
-    news_df = loader.get_news_data(
-        symbols="AAPL",
-        start="2024-01-01",
-        end="2024-01-15",
-        limit=10,
-    )
+        if not news_df.empty:
+            print(f"Retrieved {len(news_df)} news articles")
+            print("\nSample articles:")
+            for _, row in news_df.head(3).iterrows():
+                title = row.get("title", "N/A")[:60]
+                sentiment = row.get("sentiment_score", "N/A")
+                print(f"  - {title}... (sentiment: {sentiment})")
 
-    if not news_df.empty:
-        print(f"Retrieved {len(news_df)} news articles")
-        print("\nSample articles:")
-        for _, row in news_df.head(3).iterrows():
-            title = row.get("title", "N/A")[:60]
-            sentiment = row.get("sentiment_score", "N/A")
-            print(f"  - {title}... (sentiment: {sentiment})")
+    run_example_step("[6] News Sentiment Data", example_news)
 
     # ------------------------------------------------------------------
     # Example 7: Macroeconomic data - GDP
     # ------------------------------------------------------------------
-    print("\n[7] Macroeconomic Data - GDP")
-    print("-" * 40)
+    def example_gdp():
+        macro_data = loader.get_macro_data(
+            indicators=[MacroIndicator.REAL_GDP],
+            start="2020-01-01",
+            end="2024-01-01",
+        )
 
-    macro_data = loader.get_macro_data(
-        indicators=[MacroIndicator.REAL_GDP],
-        start="2020-01-01",
-        end="2024-01-01",
-    )
+        if macro_data.get("real_gdp"):
+            gdp_data = macro_data["real_gdp"]
+            if "data" in gdp_data:
+                print(f"Retrieved {len(gdp_data['data'])} GDP data points")
+                print("Latest GDP values:")
+                for item in gdp_data["data"][:3]:
+                    print(f"  {item['date']}: ${item['value']} billion")
 
-    if macro_data.get("real_gdp"):
-        gdp_data = macro_data["real_gdp"]
-        if "data" in gdp_data:
-            print(f"Retrieved {len(gdp_data['data'])} GDP data points")
-            print("Latest GDP values:")
-            for item in gdp_data["data"][:3]:
-                print(f"  {item['date']}: ${item['value']} billion")
+    run_example_step("[7] Macroeconomic Data - GDP", example_gdp)
 
     # ------------------------------------------------------------------
     # Example 8: Treasury yields
     # ------------------------------------------------------------------
-    print("\n[8] Treasury Yields")
-    print("-" * 40)
+    def example_treasury():
+        treasury = loader.get_macro_data(
+            indicators={
+                MacroIndicator.TREASURY_YIELD: {
+                    "interval": "monthly",
+                    "maturity": "10year",
+                }
+            },
+            start="2023-01-01",
+            end="2024-01-01",
+        )
 
-    treasury = loader.get_macro_data(
-        indicators={
-            MacroIndicator.TREASURY_YIELD: {
-                "interval": "monthly",
-                "maturity": "10year",
-            }
-        },
-        start="2023-01-01",
-        end="2024-01-01",
-    )
+        if treasury.get("treasury_yield"):
+            yield_data = treasury["treasury_yield"]
+            if "data" in yield_data:
+                print(f"Retrieved {len(yield_data['data'])} yield data points")
+                print("Latest 10-year Treasury yields:")
+                for item in yield_data["data"][:3]:
+                    print(f"  {item['date']}: {item['value']}%")
 
-    if treasury.get("treasury_yield"):
-        yield_data = treasury["treasury_yield"]
-        if "data" in yield_data:
-            print(f"Retrieved {len(yield_data['data'])} yield data points")
-            print("Latest 10-year Treasury yields:")
-            for item in yield_data["data"][:3]:
-                print(f"  {item['date']}: {item['value']}%")
+    run_example_step("[8] Treasury Yields", example_treasury)
 
     # ------------------------------------------------------------------
     # Example 9: Multiple macro indicators
     # ------------------------------------------------------------------
-    print("\n[9] Multiple Macro Indicators")
-    print("-" * 40)
+    def example_multiple_macro():
+        multi_macro = loader.get_macro_data(
+            indicators=[
+                MacroIndicator.CPI,
+                MacroIndicator.UNEMPLOYMENT_RATE,
+                MacroIndicator.INFLATION,
+            ],
+            start="2023-01-01",
+            end="2024-01-01",
+        )
 
-    multi_macro = loader.get_macro_data(
-        indicators=[
-            MacroIndicator.CPI,
-            MacroIndicator.UNEMPLOYMENT_RATE,
-            MacroIndicator.INFLATION,
-        ],
-        start="2023-01-01",
-        end="2024-01-01",
-    )
+        for indicator, data in multi_macro.items():
+            if data and "data" in data:
+                print(f"  {indicator}: {len(data['data'])} data points")
 
-    for indicator, data in multi_macro.items():
-        if data and "data" in data:
-            print(f"  {indicator}: {len(data['data'])} data points")
+    run_example_step("[9] Multiple Macro Indicators", example_multiple_macro)
 
     print("\n" + "=" * 60)
     print("Examples completed!")

--- a/examples/data_sources/fetch_fmp_data.py
+++ b/examples/data_sources/fetch_fmp_data.py
@@ -13,6 +13,7 @@ Requires API key.
 
 from dotenv import load_dotenv
 
+from quantrl_lab.data.exceptions import AuthenticationError, DataSourceError
 from quantrl_lab.data.sources import FMPDataSource
 
 # Load environment variables from .env file
@@ -22,142 +23,146 @@ load_dotenv()
 def main():
     # Initialize the data loader
     # API key can be provided as argument or via FMP_API_KEY environment variable
-    loader = FMPDataSource()
+    try:
+        loader = FMPDataSource()
+    except AuthenticationError:
+        print("ERROR: FMP API key not configured.")
+        print("Please set FMP_API_KEY in your .env file.")
+        return
 
     print("=" * 60)
     print("Financial Modeling Prep (FMP) Data Examples")
     print("=" * 60)
 
+    def run_example_step(title, fn):
+        print(f"\n{title}")
+        print("-" * 40)
+        try:
+            fn()
+        except DataSourceError as exc:
+            print(f"Skipped: {exc}")
+
     # ------------------------------------------------------------------
     # Example 1: Fetch historical OHLCV data (daily)
     # ------------------------------------------------------------------
-    print("\n[1] Historical OHLCV Data (Daily)")
-    print("-" * 40)
+    def example_daily():
+        df = loader.get_historical_ohlcv_data(
+            symbols="AAPL",
+            start="2025-01-01",
+            end="2026-01-01",
+            timeframe="1d",
+        )
+        print(f"Retrieved {len(df)} rows for AAPL")
+        print(df.head())
 
-    df = loader.get_historical_ohlcv_data(
-        symbols="AAPL",
-        start="2025-01-01",
-        end="2026-01-01",
-        timeframe="1d",  # Daily data
-    )
-    print(f"Retrieved {len(df)} rows for AAPL")
-    print(df.head())
+    run_example_step("[1] Historical OHLCV Data (Daily)", example_daily)
 
     # ------------------------------------------------------------------
     # Example 2: Fetch intraday data (5-minute bars)
     # ------------------------------------------------------------------
-    print("\n[2] Intraday Data (5-minute bars)")
-    print("-" * 40)
-
-    # Get last 7 days of intraday data
-    # Set fixed date range for consistency
     start_date = "2025-01-01"
     end_date = "2026-01-01"
 
-    df_intraday = loader.get_historical_ohlcv_data(
-        symbols="AAPL",
-        start=start_date,
-        end=end_date,
-        timeframe="5min",  # 5-minute bars
-    )
-    print(f"Retrieved {len(df_intraday)} 5-minute bars")
-    print(df_intraday.head())
+    def example_intraday():
+        df_intraday = loader.get_historical_ohlcv_data(
+            symbols="AAPL",
+            start=start_date,
+            end=end_date,
+            timeframe="5min",
+        )
+        print(f"Retrieved {len(df_intraday)} 5-minute bars")
+        print(df_intraday.head())
+
+    run_example_step("[2] Intraday Data (5-minute bars)", example_intraday)
 
     # ------------------------------------------------------------------
     # Example 3: Different intraday timeframes
     # ------------------------------------------------------------------
-    print("\n[3] Different Intraday Timeframes")
-    print("-" * 40)
+    def example_timeframes():
+        timeframes = ["15min", "1hour"]
+        for tf in timeframes:
+            df_tf = loader.get_historical_ohlcv_data(
+                symbols="MSFT",
+                start=start_date,
+                end=end_date,
+                timeframe=tf,
+            )
+            print(f"{tf}: Retrieved {len(df_tf)} bars")
 
-    # FMP supports: 5min, 15min, 30min, 1hour, 4hour
-    timeframes = ["15min", "1hour"]
-
-    for tf in timeframes:
-        df_tf = loader.get_historical_ohlcv_data(
-            symbols="MSFT",
-            start=start_date,
-            end=end_date,
-            timeframe=tf,
-        )
-        print(f"{tf}: Retrieved {len(df_tf)} bars")
+    run_example_step("[3] Different Intraday Timeframes", example_timeframes)
 
     # ------------------------------------------------------------------
     # Example 4: Fetch analyst grades
     # ------------------------------------------------------------------
-    print("\n[4] Historical Analyst Grades")
-    print("-" * 40)
+    def example_grades():
+        grades = loader.get_historical_grades("AAPL")
+        print(f"Retrieved {len(grades)} historical grades")
+        print(f"Columns: {grades.columns.tolist()}")
+        print(grades.head())
+        print("\nGrade Frequencies:")
+        for col in ["newGrade", "gradingCompany"]:
+            if col in grades.columns:
+                print(f"\nTop 5 {col}:")
+                print(grades[col].value_counts().head())
 
-    grades = loader.get_historical_grades("AAPL")
-    print(f"Retrieved {len(grades)} historical grades")
-    print(f"Columns: {grades.columns.tolist()}")
-    print(grades.head())
-
-    # Frequency checks for grades
-    print("\nGrade Frequencies:")
-    for col in ['newGrade', 'gradingCompany']:
-        if col in grades.columns:
-            print(f"\nTop 5 {col}:")
-            print(grades[col].value_counts().head())
+    run_example_step("[4] Historical Analyst Grades", example_grades)
 
     # ------------------------------------------------------------------
     # Example 5: Fetch analyst ratings
     # ------------------------------------------------------------------
-    print("\n[5] Historical Analyst Ratings")
-    print("-" * 40)
+    def example_ratings():
+        ratings = loader.get_historical_rating("AAPL", limit=500)
+        print(f"Retrieved {len(ratings)} historical ratings")
+        print(f"Columns: {ratings.columns.tolist()}")
+        print(ratings.head())
+        print("\nRating Frequencies:")
+        for col in ["rating", "ratingRecommendation"]:
+            if col in ratings.columns:
+                print(f"\n{col} counts:")
+                print(ratings[col].value_counts())
 
-    ratings = loader.get_historical_rating("AAPL", limit=500)
-    print(f"Retrieved {len(ratings)} historical ratings")
-    print(f"Columns: {ratings.columns.tolist()}")
-    print(ratings.head())
-
-    # Frequency checks for ratings
-    print("\nRating Frequencies:")
-    for col in ['rating', 'ratingRecommendation']:
-        if col in ratings.columns:
-            print(f"\n{col} counts:")
-            print(ratings[col].value_counts())
+    run_example_step("[5] Historical Analyst Ratings", example_ratings)
 
     # ------------------------------------------------------------------
     # Example 6: Fetch company profile
     # ------------------------------------------------------------------
-    print("\n[6] Company Profile")
-    print("-" * 40)
+    def example_profile():
+        profile = loader.get_company_profile("AAPL")
+        if not profile.empty:
+            print(f"Retrieved company profile for {profile.iloc[0].get('symbol', 'Unknown')}")
+            print("\n--- Full Profile Data ---")
+            for col, val in profile.iloc[0].items():
+                print(f"{col}: {val}")
+        else:
+            print("No profile data found.")
 
-    profile = loader.get_company_profile("AAPL")
-    if not profile.empty:
-        print(f"Retrieved company profile for {profile.iloc[0].get('symbol', 'Unknown')}")
-        print("\n--- Full Profile Data ---")
-        # Print all fields in the profile
-        for col, val in profile.iloc[0].items():
-            print(f"{col}: {val}")
-    else:
-        print("No profile data found.")
+    run_example_step("[6] Company Profile", example_profile)
 
     # ------------------------------------------------------------------
     # Example 7: Historical sector performance
     # ------------------------------------------------------------------
-    print("\n[7] Historical Sector Performance")
-    print("-" * 40)
+    def example_sector():
+        sector_perf = loader.get_historical_sector_performance("Technology", start=start_date, end=end_date)
+        print(f"Retrieved {len(sector_perf)} records for Technology sector")
+        if not sector_perf.empty and "date" in sector_perf.columns:
+            print(f"Date range: {sector_perf['date'].min()} to {sector_perf['date'].max()}")
+            print(f"Columns: {sector_perf.columns.tolist()}")
+        print(sector_perf.head())
 
-    sector_perf = loader.get_historical_sector_performance("Technology", start=start_date, end=end_date)
-    print(f"Retrieved {len(sector_perf)} records for Technology sector")
-    if not sector_perf.empty and 'date' in sector_perf.columns:
-        print(f"Date range: {sector_perf['date'].min()} to {sector_perf['date'].max()}")
-        print(f"Columns: {sector_perf.columns.tolist()}")
-    print(sector_perf.head())
+    run_example_step("[7] Historical Sector Performance", example_sector)
 
     # ------------------------------------------------------------------
     # Example 8: Historical industry performance
     # ------------------------------------------------------------------
-    print("\n[8] Historical Industry Performance")
-    print("-" * 40)
+    def example_industry():
+        industry_perf = loader.get_historical_industry_performance("Biotechnology", start=start_date, end=end_date)
+        print(f"Retrieved {len(industry_perf)} records for Biotechnology industry")
+        if not industry_perf.empty and "date" in industry_perf.columns:
+            print(f"Date range: {industry_perf['date'].min()} to {industry_perf['date'].max()}")
+            print(f"Columns: {industry_perf.columns.tolist()}")
+        print(industry_perf.head())
 
-    industry_perf = loader.get_historical_industry_performance("Biotechnology", start=start_date, end=end_date)
-    print(f"Retrieved {len(industry_perf)} records for Biotechnology industry")
-    if not industry_perf.empty and 'date' in industry_perf.columns:
-        print(f"Date range: {industry_perf['date'].min()} to {industry_perf['date'].max()}")
-        print(f"Columns: {industry_perf.columns.tolist()}")
-    print(industry_perf.head())
+    run_example_step("[8] Historical Industry Performance", example_industry)
 
     print("\n" + "=" * 60)
     print("Examples completed!")

--- a/examples/data_sources/fetch_yfinance_data.py
+++ b/examples/data_sources/fetch_yfinance_data.py
@@ -13,6 +13,17 @@ from datetime import datetime
 from quantrl_lab.data.sources import YFinanceDataLoader
 
 
+def run_example_step(title, fn):
+    """Run one example step and keep the script alive on provider
+    failures."""
+    print(f"\n{title}")
+    print("-" * 40)
+    try:
+        fn()
+    except Exception as exc:
+        print(f"Skipped: {exc}")
+
+
 def main():
     # Initialize the data loader
     loader = YFinanceDataLoader()
@@ -24,88 +35,83 @@ def main():
     # ------------------------------------------------------------------
     # Example 1: Fetch historical OHLCV data for a single symbol
     # ------------------------------------------------------------------
-    print("\n[1] Historical OHLCV Data (Single Symbol)")
-    print("-" * 40)
+    def example_single_symbol():
+        df = loader.get_historical_ohlcv_data(
+            symbols="AAPL",
+            start="2024-01-01",
+            end="2024-06-01",
+            timeframe="1d",  # Daily data
+        )
+        print(f"Retrieved {len(df)} rows for AAPL")
+        print(df.head())
 
-    df = loader.get_historical_ohlcv_data(
-        symbols="AAPL",
-        start="2024-01-01",
-        end="2024-06-01",
-        timeframe="1d",  # Daily data
-    )
-    print(f"Retrieved {len(df)} rows for AAPL")
-    print(df.head())
+    run_example_step("[1] Historical OHLCV Data (Single Symbol)", example_single_symbol)
 
     # ------------------------------------------------------------------
     # Example 2: Fetch historical data for multiple symbols
     # ------------------------------------------------------------------
-    print("\n[2] Historical OHLCV Data (Multiple Symbols)")
-    print("-" * 40)
+    def example_multi_symbol():
+        df_multi = loader.get_historical_ohlcv_data(
+            symbols=["AAPL", "GOOGL", "MSFT"],
+            start="2024-01-01",
+            end="2024-03-01",
+            timeframe="1d",
+        )
+        print(f"Retrieved {len(df_multi)} total rows")
+        print(f"Symbols: {df_multi['Symbol'].unique().tolist()}")
+        print(df_multi.head(10))
 
-    df_multi = loader.get_historical_ohlcv_data(
-        symbols=["AAPL", "GOOGL", "MSFT"],
-        start="2024-01-01",
-        end="2024-03-01",
-        timeframe="1d",
-    )
-    print(f"Retrieved {len(df_multi)} total rows")
-    print(f"Symbols: {df_multi['Symbol'].unique().tolist()}")
-    print(df_multi.head(10))
+    run_example_step("[2] Historical OHLCV Data (Multiple Symbols)", example_multi_symbol)
 
     # ------------------------------------------------------------------
     # Example 3: Fetch intraday data (1-minute bars)
     # Note: Yahoo Finance limits 1-minute data to last 30 days
     # ------------------------------------------------------------------
-    print("\n[3] Intraday Data (1-minute bars)")
-    print("-" * 40)
+    def example_intraday():
+        from datetime import timedelta
 
-    # Calculate date range within 30 days
-    from datetime import timedelta
+        end_date = datetime.now()
+        start_date = end_date - timedelta(days=7)
 
-    end_date = datetime.now()
-    start_date = end_date - timedelta(days=7)
-
-    df_intraday = loader.get_historical_ohlcv_data(
-        symbols="AAPL",
-        start=start_date,
-        end=end_date,
-        timeframe="1m",  # 1-minute bars
-    )
-    if df_intraday is not None:
+        df_intraday = loader.get_historical_ohlcv_data(
+            symbols="AAPL",
+            start=start_date,
+            end=end_date,
+            timeframe="1m",  # 1-minute bars
+        )
         print(f"Retrieved {len(df_intraday)} intraday bars")
         print(df_intraday.head())
+
+    run_example_step("[3] Intraday Data (1-minute bars)", example_intraday)
 
     # ------------------------------------------------------------------
     # Example 4: Fetch fundamental data
     # ------------------------------------------------------------------
-    print("\n[4] Fundamental Data")
-    print("-" * 40)
+    def example_fundamentals():
+        fundamentals = loader.get_fundamental_data(
+            symbol="AAPL",
+            frequency="quarterly",
+        )
+        print(f"Retrieved {len(fundamentals)} quarters of fundamental data")
+        print(f"Columns: {fundamentals.columns.tolist()[:10]}...")
+        print(fundamentals.head())
 
-    fundamentals = loader.get_fundamental_data(
-        symbol="AAPL",
-        frequency="quarterly",
-    )
-    print(f"Retrieved {len(fundamentals)} quarters of fundamental data")
-    print(f"Columns: {fundamentals.columns.tolist()[:10]}...")  # First 10 columns
-    print(fundamentals.head())
+    run_example_step("[4] Fundamental Data", example_fundamentals)
 
     # ------------------------------------------------------------------
     # Example 5: Individual financial statements
     # ------------------------------------------------------------------
-    print("\n[5] Individual Financial Statements")
-    print("-" * 40)
+    def example_statements():
+        income = loader._get_income_statement("MSFT", frequency="quarterly")
+        print(f"Income Statement: {len(income)} quarters")
 
-    # Income Statement
-    income = loader._get_income_statement("MSFT", frequency="quarterly")
-    print(f"Income Statement: {len(income)} quarters")
+        balance = loader._get_balance_sheet("MSFT", frequency="quarterly")
+        print(f"Balance Sheet: {len(balance)} quarters")
 
-    # Balance Sheet
-    balance = loader._get_balance_sheet("MSFT", frequency="quarterly")
-    print(f"Balance Sheet: {len(balance)} quarters")
+        cashflow = loader._get_cash_flow("MSFT", frequency="quarterly")
+        print(f"Cash Flow: {len(cashflow)} quarters")
 
-    # Cash Flow
-    cashflow = loader._get_cash_flow("MSFT", frequency="quarterly")
-    print(f"Cash Flow: {len(cashflow)} quarters")
+    run_example_step("[5] Individual Financial Statements", example_statements)
 
     print("\n" + "=" * 60)
     print("Examples completed!")

--- a/examples/data_sources/stream_alpaca_data.py
+++ b/examples/data_sources/stream_alpaca_data.py
@@ -9,8 +9,12 @@ This script demonstrates how to:
 Requirements:
 - Set ALPACA_API_KEY and ALPACA_SECRET_KEY in your .env file
 - Install requirements (including 'alpaca-py')
+
+Optional:
+- Pass --duration-seconds N to stop automatically after N seconds
 """
 
+import argparse
 import asyncio
 import sys
 
@@ -23,7 +27,7 @@ from quantrl_lab.data.sources import AlpacaDataLoader
 load_dotenv()
 
 
-async def main():
+async def main(duration_seconds: float = None):
     # Configure logger to show DEBUG messages (where the data is logged by default handlers)
     logger.remove()
     logger.add(sys.stderr, level="DEBUG")
@@ -54,18 +58,33 @@ async def main():
 
     logger.info("Starting stream. Press Ctrl+C to stop.")
 
+    stream_task = asyncio.create_task(loader.start_streaming())
+
     try:
-        # This will run forever until interrupted
-        await loader.start_streaming()
+        if duration_seconds is None:
+            await stream_task
+        else:
+            logger.info("Running stream for {duration:.1f}s", duration=duration_seconds)
+            await asyncio.sleep(duration_seconds)
     except KeyboardInterrupt:
         logger.info("Interrupted by user")
     finally:
         await loader.stop_streaming()
+        await stream_task
         logger.success("Stream closed")
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Stream real-time Alpaca data.")
+    parser.add_argument(
+        "--duration-seconds",
+        type=float,
+        default=None,
+        help="Optional duration for smoke-testing the stream before stopping automatically.",
+    )
+    args = parser.parse_args()
+
     try:
-        asyncio.run(main())
+        asyncio.run(main(duration_seconds=args.duration_seconds))
     except KeyboardInterrupt:
         pass

--- a/src/quantrl_lab/data/interface.py
+++ b/src/quantrl_lab/data/interface.py
@@ -1,12 +1,14 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, List, Optional, Protocol, Union, runtime_checkable
+from typing import Any, ClassVar, List, Optional, Protocol, Set, Union, runtime_checkable
 
 import pandas as pd
 
 
 class DataSource(ABC):
     """Base class for all data sources."""
+
+    SUPPORTED_FEATURES: ClassVar[Set[str]] = set()
 
     @property
     @abstractmethod
@@ -73,37 +75,7 @@ class DataSource(ABC):
     @property
     def supported_features(self) -> List[str]:
         """Return a list of supported features."""
-        features = []
-
-        if isinstance(self, HistoricalDataCapable):
-            features.append("historical_bars")
-        if isinstance(self, NewsDataCapable):
-            features.append("news")
-        if isinstance(self, LiveDataCapable):
-            features.append("live_data")
-        if isinstance(self, StreamingCapable):
-            features.append("streaming")
-        if isinstance(self, ConnectionManaged):
-            features.append("connection_managed")
-        if isinstance(self, FundamentalDataCapable):
-            features.append("fundamental_data")
-        if isinstance(self, MacroDataCapable):
-            features.append("macro_data")
-        if isinstance(self, AnalystDataCapable):
-            features.append("analyst_data")
-        if isinstance(self, SectorDataCapable):
-            features.append("sector_data")
-        if isinstance(self, CompanyProfileCapable):
-            features.append("company_profile")
-
-        # Check if instrument discovery is implemented (method is overridden)
-        if (
-            hasattr(self.__class__, "list_available_instruments")
-            and self.__class__.list_available_instruments is not DataSource.list_available_instruments
-        ):
-            features.append("instrument_discovery")
-
-        return features
+        return sorted(self.SUPPORTED_FEATURES)
 
     def supports_feature(self, feature_name: str) -> bool:
         """Check if the data source supports a specific feature."""
@@ -116,7 +88,7 @@ class DataSource(ABC):
         Returns:
             str: A string representation of the data source.
         """
-        return f"<{self.__class__.__name__}(name='{self.source_name}', connected={self.is_connected})>"
+        return f"<{self.__class__.__name__}(name='{self.source_name}', connected={self.is_connected()})>"
 
 
 @runtime_checkable

--- a/src/quantrl_lab/data/partitioning/ratio.py
+++ b/src/quantrl_lab/data/partitioning/ratio.py
@@ -1,5 +1,6 @@
 """Ratio-based data splitter for time series data."""
 
+import math
 from typing import Dict
 
 import pandas as pd
@@ -25,21 +26,21 @@ class RatioSplitter:
 
         Args:
             ratios (Dict[str, float]): Dictionary mapping split names to ratios.
-                Ratios must sum to <= 1.0. Example: {"train": 0.7, "test": 0.3}
+                Ratios must sum to 1.0. Example: {"train": 0.7, "test": 0.3}
 
         Raises:
-            ValueError: If ratios sum to > 1.0 or any ratio is invalid.
+            ValueError: If ratios do not sum to 1.0 or any ratio is invalid.
         """
         if not ratios:
             raise ValueError("Ratios dictionary cannot be empty")
 
-        total_ratio = sum(ratios.values())
-        if total_ratio > 1.0:
-            raise ValueError(f"Ratios sum to {total_ratio:.2f}, which exceeds 1.0")
-
         for name, ratio in ratios.items():
             if ratio <= 0 or ratio > 1:
                 raise ValueError(f"Invalid ratio for '{name}': {ratio}. Must be in range (0, 1]")
+
+        total_ratio = sum(ratios.values())
+        if not math.isclose(total_ratio, 1.0, rel_tol=1e-9, abs_tol=1e-9):
+            raise ValueError(f"Ratios must sum to 1.0, got {total_ratio:.6f}")
 
         self.ratios = ratios
 
@@ -74,8 +75,12 @@ class RatioSplitter:
         metadata_ranges = {}
         metadata_shapes = {}
 
-        for name, ratio in self.ratios.items():
-            end_idx = start_idx + int(total_len * ratio)
+        ratio_items = list(self.ratios.items())
+        for idx, (name, ratio) in enumerate(ratio_items):
+            if idx == len(ratio_items) - 1:
+                end_idx = total_len
+            else:
+                end_idx = start_idx + int(total_len * ratio)
             subset = df.iloc[start_idx:end_idx].copy()
             split_data[name] = subset
 

--- a/src/quantrl_lab/data/processing/features/sentiment.py
+++ b/src/quantrl_lab/data/processing/features/sentiment.py
@@ -3,12 +3,9 @@
 from typing import Dict
 
 import pandas as pd
-from rich.console import Console
 
 from quantrl_lab.data.processing.sentiment.config import SentimentConfig
 from quantrl_lab.data.processing.sentiment.provider import SentimentProvider
-
-console = Console()
 
 
 class SentimentFeatureGenerator:

--- a/src/quantrl_lab/data/processing/features/technical.py
+++ b/src/quantrl_lab/data/processing/features/technical.py
@@ -57,6 +57,13 @@ class TechnicalFeatureGenerator:
                 continue
 
             if indicator_name not in available_indicators:
+                import warnings
+
+                warnings.warn(
+                    f"Unknown indicator '{indicator_name}' — not registered in IndicatorRegistry. Skipping.",
+                    UserWarning,
+                    stacklevel=2,
+                )
                 continue
 
             try:
@@ -78,7 +85,14 @@ class TechnicalFeatureGenerator:
                     result = self.registry.apply(indicator_name, result, **custom_params)
                 else:
                     result = self.registry.apply(indicator_name, result)
-            except Exception:
+            except Exception as e:
+                import warnings
+
+                warnings.warn(
+                    f"Failed to apply indicator '{indicator_name}': {e}",
+                    UserWarning,
+                    stacklevel=2,
+                )
                 continue
 
         return result

--- a/src/quantrl_lab/data/processing/metadata.py
+++ b/src/quantrl_lab/data/processing/metadata.py
@@ -1,0 +1,110 @@
+"""
+Processing metadata dataclass.
+
+Extracted from ``processor.py`` into its own module (fix for D-5) to break
+the circular import chain where all pipeline step files imported from
+``processor.py``, which itself imports from the pipeline and steps.
+
+The dependency graph is now:
+    steps/* → metadata.py          (leaf — no further processing imports)
+    pipeline.py → metadata.py      (clean)
+    processor.py → metadata.py     (clean)
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple, Union
+
+
+@dataclass
+class ProcessingMetadata:
+    """
+    Metadata collected during data processing pipeline.
+
+    This dataclass tracks all transformations and operations applied during
+    the data processing pipeline, providing transparency and reproducibility.
+
+    Attributes:
+        symbol (Optional[Union[str, List[str]]]): Stock symbol(s) being processed.
+            Single symbol as string, multiple as list.
+        date_ranges (Dict[str, Dict[str, str]]): Date ranges for each data split.
+            Format: {"split_name": {"start": "YYYY-MM-DD", "end": "YYYY-MM-DD"}}
+        fillna_strategy (str): Strategy used for filling missing sentiment scores.
+            Options: "neutral" (fill with 0.0) or "fill_forward" (forward fill)
+        technical_indicators (List[Union[str, Dict]]): List of technical indicators applied.
+            Can contain strings ("SMA") or dicts ({"SMA": {"window": 20}})
+        news_sentiment_applied (bool): Whether news sentiment analysis was performed.
+        columns_dropped (List[str]): List of columns dropped during processing.
+        original_shape (Tuple[int, int]): Shape of input data before processing (rows, cols).
+        final_shapes (Dict[str, Tuple[int, int]]): Shapes of output data after processing.
+            Format: {"split_name": (rows, cols)} or {"full_data": (rows, cols)}
+
+    Examples:
+        >>> metadata = ProcessingMetadata(
+        ...     symbol="AAPL",
+        ...     fillna_strategy="neutral",
+        ...     original_shape=(1000, 7)
+        ... )
+        >>> metadata.technical_indicators = ["SMA", "RSI"]
+        >>> metadata.to_dict()
+    """
+
+    symbol: Optional[Union[str, List[str]]] = None
+    date_ranges: Dict[str, Dict[str, str]] = field(default_factory=dict)
+    fillna_strategy: str = "neutral"
+    technical_indicators: List[Union[str, Dict]] = field(default_factory=list)
+    cross_sectional_features: List[str] = field(default_factory=list)
+    news_sentiment_applied: bool = False
+    analyst_data_applied: bool = False
+    market_context_applied: bool = False
+    alpha_selection_config: Optional[Dict] = None
+    columns_dropped: List[str] = field(default_factory=list)
+    required_non_null_columns: List[str] = field(default_factory=list)
+    optional_feature_columns: List[str] = field(default_factory=list)
+    original_shape: Tuple[int, int] = (0, 0)
+    final_shapes: Dict[str, Tuple[int, int]] = field(default_factory=dict)
+
+    def add_required_columns(self, columns: List[str]) -> None:
+        """Track columns that must be present after processing."""
+        for column in columns:
+            if column not in self.required_non_null_columns and column not in self.optional_feature_columns:
+                self.required_non_null_columns.append(column)
+
+    def add_optional_columns(self, columns: List[str]) -> None:
+        """Track sparse feature columns that should not drive row
+        drops."""
+        for column in columns:
+            if column not in self.optional_feature_columns:
+                self.optional_feature_columns.append(column)
+            if column in self.required_non_null_columns:
+                self.required_non_null_columns.remove(column)
+
+    def to_dict(self) -> Dict:
+        """
+        Convert metadata to dictionary format for backward
+        compatibility.
+
+        Returns:
+            Dict: Dictionary representation of metadata with all fields.
+
+        Examples:
+            >>> metadata = ProcessingMetadata(symbol="AAPL", original_shape=(100, 5))
+            >>> result = metadata.to_dict()
+            >>> assert result["symbol"] == "AAPL"
+            >>> assert result["original_shape"] == (100, 5)
+        """
+        return {
+            "symbol": self.symbol,
+            "date_ranges": self.date_ranges,
+            "fillna_strategy": self.fillna_strategy,
+            "technical_indicators": self.technical_indicators,
+            "cross_sectional_features": self.cross_sectional_features,
+            "news_sentiment_applied": self.news_sentiment_applied,
+            "analyst_data_applied": self.analyst_data_applied,
+            "market_context_applied": self.market_context_applied,
+            "alpha_selection_config": self.alpha_selection_config,
+            "columns_dropped": self.columns_dropped,
+            "required_non_null_columns": self.required_non_null_columns,
+            "optional_feature_columns": self.optional_feature_columns,
+            "original_shape": self.original_shape,
+            "final_shapes": self.final_shapes,
+        }

--- a/src/quantrl_lab/data/processing/pipeline.py
+++ b/src/quantrl_lab/data/processing/pipeline.py
@@ -11,7 +11,7 @@ from typing import List, Tuple
 import pandas as pd
 from loguru import logger
 
-from quantrl_lab.data.processing.processor import ProcessingMetadata
+from quantrl_lab.data.processing.metadata import ProcessingMetadata
 from quantrl_lab.data.processing.steps.base import ProcessingStep
 
 
@@ -81,6 +81,9 @@ class DataPipeline:
         metadata = ProcessingMetadata(
             symbol=symbol,
             original_shape=df.shape,
+        )
+        metadata.add_required_columns(
+            [col for col in df.columns if col.lower() in {"open", "high", "low", "close", "volume"}]
         )
 
         # Execute steps sequentially

--- a/src/quantrl_lab/data/processing/processor.py
+++ b/src/quantrl_lab/data/processing/processor.py
@@ -1,11 +1,10 @@
 import json
 import os
-from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 import yaml
-from rich.console import Console
+from loguru import logger
 
 # Import centralized configuration
 from quantrl_lab.data.config import config
@@ -15,89 +14,16 @@ from quantrl_lab.data.processing.features.sentiment import SentimentFeatureGener
 # Import new feature generators
 from quantrl_lab.data.processing.features.technical import TechnicalFeatureGenerator
 
+# D-5: ProcessingMetadata moved to its own module to break the circular import
+# chain where all pipeline step files imported from processor.py.
+# Re-exported here for backward compatibility with existing user code.
+from quantrl_lab.data.processing.metadata import ProcessingMetadata  # noqa: F401
+
 # Import sentiment modules
 from quantrl_lab.data.processing.sentiment import (
     HuggingFaceProvider,
     SentimentConfig,
 )
-
-console: Console = Console()
-
-
-@dataclass
-class ProcessingMetadata:
-    """
-    Metadata collected during data processing pipeline.
-
-    This dataclass tracks all transformations and operations applied during
-    the data processing pipeline, providing transparency and reproducibility.
-
-    Attributes:
-        symbol (Optional[Union[str, List[str]]]): Stock symbol(s) being processed.
-            Single symbol as string, multiple as list.
-        date_ranges (Dict[str, Dict[str, str]]): Date ranges for each data split.
-            Format: {"split_name": {"start": "YYYY-MM-DD", "end": "YYYY-MM-DD"}}
-        fillna_strategy (str): Strategy used for filling missing sentiment scores.
-            Options: "neutral" (fill with 0.0) or "fill_forward" (forward fill)
-        technical_indicators (List[Union[str, Dict]]): List of technical indicators applied.
-            Can contain strings ("SMA") or dicts ({"SMA": {"window": 20}})
-        news_sentiment_applied (bool): Whether news sentiment analysis was performed.
-        columns_dropped (List[str]): List of columns dropped during processing.
-        original_shape (Tuple[int, int]): Shape of input data before processing (rows, cols).
-        final_shapes (Dict[str, Tuple[int, int]]): Shapes of output data after processing.
-            Format: {"split_name": (rows, cols)} or {"full_data": (rows, cols)}
-
-    Examples:
-        >>> metadata = ProcessingMetadata(
-        ...     symbol="AAPL",
-        ...     fillna_strategy="neutral",
-        ...     original_shape=(1000, 7)
-        ... )
-        >>> metadata.technical_indicators = ["SMA", "RSI"]
-        >>> metadata.to_dict()
-    """
-
-    symbol: Optional[Union[str, List[str]]] = None
-    date_ranges: Dict[str, Dict[str, str]] = field(default_factory=dict)
-    fillna_strategy: str = "neutral"
-    technical_indicators: List[Union[str, Dict]] = field(default_factory=list)
-    cross_sectional_features: List[str] = field(default_factory=list)
-    news_sentiment_applied: bool = False
-    analyst_data_applied: bool = False
-    market_context_applied: bool = False
-    alpha_selection_config: Optional[Dict] = None
-    columns_dropped: List[str] = field(default_factory=list)
-    original_shape: Tuple[int, int] = (0, 0)
-    final_shapes: Dict[str, Tuple[int, int]] = field(default_factory=dict)
-
-    def to_dict(self) -> Dict:
-        """
-        Convert metadata to dictionary format for backward
-        compatibility.
-
-        Returns:
-            Dict: Dictionary representation of metadata with all fields
-
-        Examples:
-            >>> metadata = ProcessingMetadata(symbol="AAPL", original_shape=(100, 5))
-            >>> result = metadata.to_dict()
-            >>> assert result["symbol"] == "AAPL"
-            >>> assert result["original_shape"] == (100, 5)
-        """
-        return {
-            "symbol": self.symbol,
-            "date_ranges": self.date_ranges,
-            "fillna_strategy": self.fillna_strategy,
-            "technical_indicators": self.technical_indicators,
-            "cross_sectional_features": self.cross_sectional_features,
-            "news_sentiment_applied": self.news_sentiment_applied,
-            "analyst_data_applied": self.analyst_data_applied,
-            "market_context_applied": self.market_context_applied,
-            "alpha_selection_config": self.alpha_selection_config,
-            "columns_dropped": self.columns_dropped,
-            "original_shape": self.original_shape,
-            "final_shapes": self.final_shapes,
-        }
 
 
 class DataProcessor:
@@ -141,27 +67,41 @@ class DataProcessor:
         except Exception as e:
             raise ValueError(f"Failed to load indicator config from {file_path}: {e}")
 
-    def __init__(self, ohlcv_data: pd.DataFrame, **kwargs):
+    def __init__(
+        self,
+        ohlcv_data: pd.DataFrame,
+        *,
+        news_data: Optional[pd.DataFrame] = None,
+        analyst_grades: Optional[pd.DataFrame] = None,
+        analyst_ratings: Optional[pd.DataFrame] = None,
+        sector_performance: Optional[pd.DataFrame] = None,
+        industry_performance: Optional[pd.DataFrame] = None,
+        fundamental_data: Optional[pd.DataFrame] = None,
+        macro_data: Optional[pd.DataFrame] = None,
+        calendar_event_data: Optional[pd.DataFrame] = None,
+        sentiment_config: Optional[SentimentConfig] = None,
+        sentiment_provider: Optional[object] = None,
+    ):
         if ohlcv_data is None:
             raise ValueError("Required parameter 'ohlcv_data' is missing.")
 
-        self.ohlcv_data = ohlcv_data  # minimal required data
+        self.ohlcv_data = ohlcv_data
 
-        # === Optional data sources ===
-        self.news_data = kwargs.get("news_data", None)
-        self.fundamental_data = kwargs.get("fundamental_data", None)
-        self.macro_data = kwargs.get("macro_data", None)
-        self.calendar_event_data = kwargs.get("calendar_event_data", None)
+        # Optional enrichment data
+        self.news_data = news_data
+        self.fundamental_data = fundamental_data
+        self.macro_data = macro_data
+        self.calendar_event_data = calendar_event_data
 
-        # === Analyst & Context Data ===
-        self.analyst_grades = kwargs.get("analyst_grades", None)
-        self.analyst_ratings = kwargs.get("analyst_ratings", None)
-        self.sector_performance = kwargs.get("sector_performance", None)
-        self.industry_performance = kwargs.get("industry_performance", None)
+        # Analyst & market-context data
+        self.analyst_grades = analyst_grades
+        self.analyst_ratings = analyst_ratings
+        self.sector_performance = sector_performance
+        self.industry_performance = industry_performance
 
-        # === Sentiment configuration and provider ===
-        self.sentiment_config = kwargs.get("sentiment_config", SentimentConfig())
-        self.sentiment_provider = kwargs.get("sentiment_provider")
+        # Sentiment configuration and provider
+        self.sentiment_config = sentiment_config if sentiment_config is not None else SentimentConfig()
+        self.sentiment_provider = sentiment_provider
 
         if self.sentiment_provider is None and self.news_data is not None:
             # Default to HuggingFaceProvider if news data is present but no provider given
@@ -191,15 +131,8 @@ class DataProcessor:
         if not indicators:
             return df.copy()
 
-        try:
-            generator = TechnicalFeatureGenerator(indicators)
-            return generator.generate(df, **kwargs)
-        except ValueError as e:
-            # Re-raise with same message or log
-            raise e
-        except Exception as e:
-            console.print(f"[red]❌ Failed to append technical indicators: {e}[/red]")
-            return df.copy()
+        generator = TechnicalFeatureGenerator(indicators)
+        return generator.generate(df, **kwargs)
 
     def append_news_sentiment_data(self, df: pd.DataFrame, fillna_strategy="neutral") -> pd.DataFrame:
         """
@@ -216,19 +149,13 @@ class DataProcessor:
             pd.DataFrame: DataFrame with appended news sentiment data.
         """
         if self.news_data is None or self.news_data.empty:
-            console.print("[yellow]⚠️  No news data provided. Skipping sentiment analysis.[/yellow]")
+            logger.debug("No news data provided. Skipping sentiment analysis.")
             return df
 
-        try:
-            generator = SentimentFeatureGenerator(
-                self.sentiment_provider, self.sentiment_config, self.news_data, fillna_strategy
-            )
-            return generator.generate(df)
-        except ValueError as e:
-            raise e
-        except Exception as e:
-            console.print(f"[red]❌ Failed to append sentiment data: {e}[/red]")
-            return df
+        generator = SentimentFeatureGenerator(
+            self.sentiment_provider, self.sentiment_config, self.news_data, fillna_strategy
+        )
+        return generator.generate(df)
 
     def drop_unwanted_columns(
         self, df: pd.DataFrame, columns_to_drop: Optional[List[str]] = None, keep_date: bool = False
@@ -244,17 +171,9 @@ class DataProcessor:
         Returns:
             pd.DataFrame: DataFrame with specified columns dropped.
         """
-        if columns_to_drop is None:
-            columns_to_drop = [config.DEFAULT_DATE_COLUMN, "Timestamp", "Symbol"]
-        elif not isinstance(columns_to_drop, list):
-            raise ValueError(
-                f"Invalid type for 'columns_to_drop': expected list, got {type(columns_to_drop).__name__}."
-            )
+        from quantrl_lab.data.processing.steps import ColumnCleanupStep
 
-        if keep_date:
-            columns_to_drop = [col for col in columns_to_drop if col not in config.DATE_COLUMNS]
-
-        return df.drop(columns=columns_to_drop, errors="ignore")
+        return ColumnCleanupStep(columns_to_drop=columns_to_drop, keep_date=keep_date).process(df, ProcessingMetadata())
 
     def convert_columns_to_numeric(self, df: pd.DataFrame, columns: Optional[List[str]] = None) -> pd.DataFrame:
         """
@@ -268,32 +187,9 @@ class DataProcessor:
         Returns:
             pd.DataFrame: DataFrame with numeric conversions applied
         """
-        if columns is None:
-            # Only convert object columns that are not date-like
-            columns = []
-            for col in df.columns:
-                if df[col].dtype == "object":
-                    # Skip columns that look like dates
-                    if col in config.DATE_COLUMNS or col.lower() in [c.lower() for c in config.DATE_COLUMNS]:
-                        continue
-                    # Check if it's actually a date column by looking at the data
-                    sample_val = df[col].dropna().iloc[0] if not df[col].dropna().empty else None
-                    if sample_val is not None:
-                        try:
-                            pd.to_datetime(sample_val)
-                            # If conversion succeeds, it's probably a date column - skip it
-                            continue
-                        except (ValueError, TypeError):
-                            # Not a date, safe to convert to numeric
-                            columns.append(col)
-        elif not isinstance(columns, list):
-            raise ValueError(f"Invalid type for 'columns': expected list, got {type(columns).__name__}.")
+        from quantrl_lab.data.processing.steps import NumericConversionStep
 
-        for col in columns:
-            if col in df.columns and df[col].dtype == "object":
-                df[col] = pd.to_numeric(df[col], errors="coerce")
-
-        return df
+        return NumericConversionStep(columns=columns).process(df, ProcessingMetadata())
 
     def data_processing_pipeline(
         self,
@@ -347,10 +243,22 @@ class DataProcessor:
             TechnicalIndicatorStep,
         )
 
+        # Resolve indicators — auto-select via AlphaSelector when requested
+        if alpha_selection_config is not None and indicators is None:
+            from quantrl_lab.alpha_research.selector import AlphaSelector
+
+            selector = AlphaSelector(self.ohlcv_data, verbose=kwargs.get("verbose", False))
+            indicators = selector.suggest_indicators(
+                candidates=alpha_selection_config.get("candidates"),
+                metric=alpha_selection_config.get("metric", "ic"),
+                threshold=alpha_selection_config.get("threshold", 0.0),
+                top_k=alpha_selection_config.get("top_k", 5),
+            )
+
         # Build pipeline
         pipeline = DataPipeline()
 
-        # 1. Technical Indicators (Manual)
+        # 1. Technical Indicators
         pipeline.add_step(TechnicalIndicatorStep(indicators=indicators))
 
         # 2. Analyst Estimates
@@ -405,6 +313,8 @@ class DataProcessor:
             metadata_obj.analyst_data_applied = True
         if self.sector_performance is not None or self.industry_performance is not None:
             metadata_obj.market_context_applied = True
+        if alpha_selection_config is not None:
+            metadata_obj.alpha_selection_config = alpha_selection_config
 
         # Handle Data Splitting (Post-Processing)
         # Debug: Check for columns with all NaN values before dropna
@@ -413,28 +323,28 @@ class DataProcessor:
             null_counts = processed_data.isnull().sum()
             all_null_cols = null_counts[null_counts == len(processed_data)]
             if not all_null_cols.empty:
-                console.print(f"[yellow]⚠️  Warning: Columns with all NaN values: {list(all_null_cols.index)}[/yellow]")
+                logger.warning("Columns with all NaN values: {columns}", columns=list(all_null_cols.index))
 
-            console.print(f"[cyan]Before dropna: {len(processed_data)} rows[/cyan]")
-            console.print(f"[cyan]Columns in DataFrame: {list(processed_data.columns)}[/cyan]")
+            logger.info("Before dropna: {rows} rows", rows=len(processed_data))
+            logger.info("Columns in DataFrame: {columns}", columns=list(processed_data.columns))
 
-        # Drop rows with any NaN values
-        # This handles:
-        # 1. Indicator warm-up periods (e.g., SMA(200) creates 200 leading NaNs)
-        # 2. Missing price data
-        # 3. Any other features that couldn't be computed/filled
+        required_columns = [col for col in metadata_obj.required_non_null_columns if col in processed_data.columns]
         initial_len = len(processed_data)
-        processed_data = processed_data.dropna().reset_index(drop=True)
+        processed_data = processed_data.dropna(subset=required_columns or None)
         dropped_count = initial_len - len(processed_data)
 
         if verbose:
             if dropped_count > 0:
-                console.print(f"[yellow]Dropped {dropped_count} rows containing NaNs (indicator warm-up, etc)[/yellow]")
+                logger.info(
+                    "Dropped {count} rows containing NaNs in required columns: {columns}",
+                    count=dropped_count,
+                    columns=required_columns,
+                )
             else:
-                console.print("[green]No rows dropped (data is clean)[/green]")
+                logger.info("No rows dropped (data is clean)")
 
         if verbose:
-            console.print(f"[cyan]After dropna: {len(processed_data)} rows[/cyan]")
+            logger.info("After dropna: {rows} rows", rows=len(processed_data))
 
         if split_config:
             split_data, split_metadata = self._split_data(processed_data, split_config)
@@ -489,20 +399,32 @@ class DataProcessor:
         Returns:
             Tuple[Dict[str, pd.DataFrame], Dict]: datasets in dict and metadata
         """
+        # If the DataFrame has a DatetimeIndex, promote it to a column so
+        # RatioSplitter / DateRangeSplitter can sort by it without ambiguity.
+        original_index_name = df.index.name
+        index_name = original_index_name or "Date"
+        has_datetime_index = hasattr(df.index, "dtype") and pd.api.types.is_datetime64_any_dtype(df.index)
+        if has_datetime_index:
+            df = df.reset_index()
+            if df.columns[0] != index_name:
+                df = df.rename(columns={df.columns[0]: index_name})
+
         # Determine split type based on config values
         is_date_based = any(isinstance(v, (tuple, list)) for v in split_config.values())
 
         if is_date_based:
-            # Use DateRangeSplitter
             splitter = DateRangeSplitter(split_config)
         else:
-            # Use RatioSplitter
             splitter = RatioSplitter(split_config)
 
-        # Perform split
         split_data = splitter.split(df)
-
-        # Get metadata from splitter
         metadata = splitter.get_metadata()
+
+        # Restore the DatetimeIndex on each split and drop the temporary column
+        if has_datetime_index:
+            for key in split_data:
+                if index_name in split_data[key].columns:
+                    split_data[key] = split_data[key].set_index(index_name)
+                    split_data[key].index.name = original_index_name
 
         return split_data, metadata

--- a/src/quantrl_lab/data/processing/sentiment/provider.py
+++ b/src/quantrl_lab/data/processing/sentiment/provider.py
@@ -3,14 +3,12 @@
 from typing import TYPE_CHECKING, Optional, Protocol, runtime_checkable
 
 import pandas as pd
-from rich.console import Console
+from loguru import logger
 
 from .config import HuggingFaceConfig, SentimentConfig
 
 if TYPE_CHECKING:
     from transformers import Pipeline
-
-console = Console()
 
 
 @runtime_checkable
@@ -58,6 +56,9 @@ class HuggingFaceProvider:
         """
         self.hf_config = hf_config or HuggingFaceConfig()
         self._pipeline: Optional["Pipeline"] = None
+        # Tracks whether we're running on a hardware accelerator (CUDA/MPS) so
+        # we can safely choose a larger batch size for higher throughput.
+        self._uses_accelerator = False
 
     def _get_pipeline(self) -> "Pipeline":
         """
@@ -80,8 +81,22 @@ class HuggingFaceProvider:
                 ) from e
 
             try:
-                # Use GPU if available and device is set to 0
-                device = 0 if torch.cuda.is_available() and self.hf_config.device == 0 else -1
+                # Prefer hardware acceleration for higher inference throughput:
+                # 1) CUDA on NVIDIA GPUs, 2) MPS on Apple Silicon, 3) CPU fallback.
+                # This specifically speeds up macOS arm64 by using MPS instead of CPU.
+                device: object = -1
+                backend = "cpu"
+                self._uses_accelerator = False
+
+                if self.hf_config.device == 0:
+                    if torch.cuda.is_available():
+                        device = 0
+                        backend = "cuda"
+                        self._uses_accelerator = True
+                    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                        device = "mps"
+                        backend = "mps"
+                        self._uses_accelerator = True
 
                 pipeline_kwargs = {
                     "model": self.hf_config.model_name,
@@ -91,13 +106,19 @@ class HuggingFaceProvider:
                     "top_k": self.hf_config.top_k,
                 }
 
+                # FP16 reduces memory bandwidth and typically improves inference latency
+                # on accelerators (CUDA/MPS) while preserving practical sentiment quality.
+                if self._uses_accelerator:
+                    pipeline_kwargs["dtype"] = torch.float16
+
                 if self.hf_config.max_length:
                     pipeline_kwargs["max_length"] = self.hf_config.max_length
 
                 self._pipeline = pipeline("sentiment-analysis", **pipeline_kwargs)
-                console.print(
-                    f"[green]✓ Sentiment analysis pipeline initialized with model: "
-                    f"{self.hf_config.model_name}[/green]"
+                logger.info(
+                    "Sentiment analysis pipeline initialized with model {model} (backend={backend})",
+                    model=self.hf_config.model_name,
+                    backend=backend,
                 )
             except Exception as e:
                 raise RuntimeError(f"Failed to load sentiment model: {e}")
@@ -143,13 +164,13 @@ class HuggingFaceProvider:
 
         # === Process sentiment scores ===
         if config.sentiment_score_column in text_data.columns:
-            console.print("[green]✓ Using pre-existing sentiment scores.[/green]")
+            logger.info("Using pre-existing sentiment scores.")
             # Ensure the sentiment score column is numeric
             text_data[config.sentiment_score_column] = pd.to_numeric(
                 text_data[config.sentiment_score_column], errors="coerce"
             )
         else:
-            console.print("[cyan]Calculating sentiment scores using HuggingFace model...[/cyan]")
+            logger.info("Calculating sentiment scores using HuggingFace model.")
             # === Initialize pipeline ===
             sentiment_pipeline = self._get_pipeline()
 
@@ -159,10 +180,27 @@ class HuggingFaceProvider:
             if not texts_to_analyze:
                 raise ValueError("No valid text data found for sentiment analysis")
 
+            # Use a larger effective batch size on accelerators to improve
+            # throughput. CPU keeps user-configured size to avoid memory spikes.
+            effective_batch_size = self.hf_config.batch_size
+            if self._uses_accelerator:
+                effective_batch_size = max(self.hf_config.batch_size, 32)
+
             # === Run sentiment analysis ===
+            # Prefer a datasets-backed iterator when available; it reduces
+            # Python overhead and can speed up preprocessing for large inputs.
+            inference_input: object = texts_to_analyze
+            try:
+                from datasets import Dataset
+
+                inference_input = Dataset.from_dict({"text": texts_to_analyze})["text"]
+            except Exception:
+                # Fallback to plain Python list when datasets is unavailable.
+                inference_input = texts_to_analyze
+
             sentiments = sentiment_pipeline(
-                texts_to_analyze,
-                batch_size=self.hf_config.batch_size,
+                inference_input,
+                batch_size=effective_batch_size,
                 truncation=self.hf_config.truncation,
             )
 

--- a/src/quantrl_lab/data/processing/steps/alternative/analyst.py
+++ b/src/quantrl_lab/data/processing/steps/alternative/analyst.py
@@ -1,11 +1,10 @@
 """Analyst data processing steps."""
 
 import pandas as pd
-from rich.console import Console
+from loguru import logger
 
-from quantrl_lab.data.processing.processor import ProcessingMetadata
-
-console = Console()
+from quantrl_lab.data.processing.metadata import ProcessingMetadata
+from quantrl_lab.data.utils import merge_asof_features
 
 
 class AnalystEstimatesStep:
@@ -40,100 +39,47 @@ class AnalystEstimatesStep:
         if (self.grades_df is None or self.grades_df.empty) and (self.ratings_df is None or self.ratings_df.empty):
             return data
 
-        # Ensure working copy and set index to datetime for merging
         df = data.copy()
-
-        # Identify date column for merging
-        date_col = None
-        if isinstance(df.index, pd.DatetimeIndex):
-            pass  # Index is already good
-        elif "Timestamp" in df.columns:
-            df["Timestamp"] = pd.to_datetime(df["Timestamp"])
-            df.set_index("Timestamp", inplace=True)
-            date_col = "Timestamp"
-        elif "Date" in df.columns:
-            df["Date"] = pd.to_datetime(df["Date"])
-            df.set_index("Date", inplace=True)
-            date_col = "Date"
-
-        # Normalize index to tz-naive UTC and midnight to prevent join errors
-        if isinstance(df.index, pd.DatetimeIndex):
-            if df.index.tz is not None:
-                df.index = df.index.tz_convert("UTC").tz_localize(None)
-            df.index = df.index.normalize()
-
-        # Helper to prepare month key for joining
-        # We use to_period('M') to match "2023-01-03" (Data) with "2023-01-01" (Grade)
-        df["_join_month"] = df.index.to_period("M")
 
         # --- Process Grades ---
         if self.grades_df is not None and not self.grades_df.empty:
             grades = self.grades_df.copy()
             if "date" in grades.columns:
-                grades["date"] = pd.to_datetime(grades["date"])
-
-                # Create join key
-                grades["_join_month"] = grades["date"].dt.to_period("M")
-
-                # Deduplicate: Keep the last rating for the month if multiple exist
-                # This prevents row explosion (Cartesian product) if FMP has >1 record/month
-                grades = grades.sort_values("date").drop_duplicates(subset=["_join_month"], keep="last")
-
-                # Drop redundant columns
-                grades = grades.drop(columns=["symbol", "date"], errors="ignore")
-
-                # Merge on month key
-                # We use reset_index() on df to preserve the DatetimeIndex during merge
-                # then set it back.
-                df_reset = df.reset_index()
-
-                # Merge
-                merged = pd.merge(df_reset, grades, on="_join_month", how="left", suffixes=("", "_grade"))
-
-                # Restore index
-                if date_col:
-                    merged.set_index(date_col, inplace=True)
-                else:
-                    # Fallback if date_col wasn't explicitly tracked (shouldn't happen given logic above)
-                    merged.set_index(df.index.name or "index", inplace=True)
-
-                df = merged
+                dedupe_columns = ["date", "symbol"] if "symbol" in grades.columns else ["date"]
+                grades = grades.sort_values(dedupe_columns).drop_duplicates(subset=dedupe_columns, keep="last")
+                base_by_columns = ["Symbol"] if "Symbol" in df.columns and "symbol" in grades.columns else []
+                feature_by_columns = ["symbol"] if base_by_columns else []
+                df, added_columns = merge_asof_features(
+                    df,
+                    grades,
+                    feature_date_column="date",
+                    drop_columns=["symbol"],
+                    base_by_columns=base_by_columns,
+                    feature_by_columns=feature_by_columns,
+                )
+                metadata.add_optional_columns(added_columns)
+            else:
+                logger.warning("Analyst grades data is missing a 'date' column. Skipping grades enrichment.")
 
         # --- Process Ratings ---
         if self.ratings_df is not None and not self.ratings_df.empty:
             ratings = self.ratings_df.copy()
             if "date" in ratings.columns:
-                ratings["date"] = pd.to_datetime(ratings["date"])
-
-                # Create join key
-                ratings["_join_month"] = ratings["date"].dt.to_period("M")
-
-                # Deduplicate
-                ratings = ratings.sort_values("date").drop_duplicates(subset=["_join_month"], keep="last")
-
-                # Drop redundant columns
-                ratings = ratings.drop(columns=["symbol", "rating", "date"], errors="ignore")
-
-                # Merge
-                df_reset = df.reset_index()
-
-                merged = pd.merge(df_reset, ratings, on="_join_month", how="left", suffixes=("", "_rating"))
-
-                # Restore index
-                if date_col:
-                    merged.set_index(date_col, inplace=True)
-                else:
-                    merged.set_index(df.index.name or "index", inplace=True)
-
-                df = merged
-
-        # Cleanup join key
-        if "_join_month" in df.columns:
-            df = df.drop(columns=["_join_month"])
-
-        # Reset index if we changed it
-        if date_col:
-            df.reset_index(inplace=True)
+                dedupe_columns = ["date", "symbol"] if "symbol" in ratings.columns else ["date"]
+                ratings = ratings.sort_values(dedupe_columns).drop_duplicates(subset=dedupe_columns, keep="last")
+                base_by_columns = ["Symbol"] if "Symbol" in df.columns and "symbol" in ratings.columns else []
+                feature_by_columns = ["symbol"] if base_by_columns else []
+                df, added_columns = merge_asof_features(
+                    df,
+                    ratings,
+                    feature_date_column="date",
+                    drop_columns=["symbol", "rating"],
+                    base_by_columns=base_by_columns,
+                    feature_by_columns=feature_by_columns,
+                )
+                metadata.add_optional_columns(added_columns)
+            else:
+                logger.warning("Analyst ratings data is missing a 'date' column. Skipping ratings enrichment.")
 
         return df
 

--- a/src/quantrl_lab/data/processing/steps/alternative/sentiment.py
+++ b/src/quantrl_lab/data/processing/steps/alternative/sentiment.py
@@ -1,13 +1,11 @@
 """Sentiment enrichment processing step."""
 
 import pandas as pd
-from rich.console import Console
+from loguru import logger
 
 from quantrl_lab.data.processing.features.sentiment import SentimentFeatureGenerator
-from quantrl_lab.data.processing.processor import ProcessingMetadata
+from quantrl_lab.data.processing.metadata import ProcessingMetadata
 from quantrl_lab.data.processing.sentiment import SentimentConfig, SentimentProvider
-
-console = Console()
 
 
 class SentimentEnrichmentStep:
@@ -62,39 +60,34 @@ class SentimentEnrichmentStep:
             ValueError: If news_data is empty or invalid
         """
         if self.news_data is None or self.news_data.empty:
-            console.print("[yellow]⚠️  No news data provided. Skipping sentiment analysis.[/yellow]")
+            logger.debug("No news data provided. Skipping sentiment analysis.")
             return data
 
-        try:
-            # SentimentFeatureGenerator expects 'Date' as a column.
-            # If Date is the index, temporarily move it to a column.
-            restored_index = False
-            df = data
-            if "Date" not in df.columns and df.index.name == "Date":
-                df = df.reset_index()
-                restored_index = True
+        restored_index = False
+        df = data
+        if "Date" not in df.columns and df.index.name == "Date":
+            df = df.reset_index()
+            restored_index = True
 
-            generator = SentimentFeatureGenerator(
-                self.provider,
-                self.config,
-                self.news_data,
-                self.fillna_strategy,
-            )
-            result = generator.generate(df)
+        generator = SentimentFeatureGenerator(
+            self.provider,
+            self.config,
+            self.news_data,
+            self.fillna_strategy,
+        )
+        result = generator.generate(df)
 
-            if restored_index and "Date" in result.columns:
-                result = result.set_index("Date")
+        if restored_index and "Date" in result.columns:
+            result = result.set_index("Date")
 
-            # Update metadata
-            metadata.news_sentiment_applied = True
-            metadata.fillna_strategy = self.fillna_strategy
+        metadata.news_sentiment_applied = True
+        metadata.fillna_strategy = self.fillna_strategy
+        required_columns = [col for col in result.columns if col not in data.columns]
+        if "sentiment_score" in result.columns:
+            required_columns.append("sentiment_score")
+        metadata.add_required_columns(required_columns)
 
-            return result
-        except ValueError as e:
-            raise e
-        except Exception as e:
-            console.print(f"[red]❌ Failed to add sentiment data: {e}[/red]")
-            return data
+        return result
 
     def get_step_name(self) -> str:
         """Return step name."""

--- a/src/quantrl_lab/data/processing/steps/features/context.py
+++ b/src/quantrl_lab/data/processing/steps/features/context.py
@@ -1,11 +1,9 @@
 """Market context processing steps."""
 
 import pandas as pd
-from rich.console import Console
 
-from quantrl_lab.data.processing.processor import ProcessingMetadata
-
-console = Console()
+from quantrl_lab.data.processing.metadata import ProcessingMetadata
+from quantrl_lab.data.utils import merge_asof_features
 
 
 class MarketContextStep:
@@ -43,69 +41,33 @@ class MarketContextStep:
 
         df = data.copy()
 
-        # Setup index for merging
-        date_col = None
-        temp_index = False
-        if not isinstance(df.index, pd.DatetimeIndex):
-            # Try to find date column
-            for col in ["Timestamp", "Date", "date"]:
-                if col in df.columns:
-                    df[col] = pd.to_datetime(df[col])
-                    df.set_index(col, inplace=True)
-                    date_col = col
-                    temp_index = True
-                    break
-
-        # Normalize index to tz-naive UTC midnight to prevent join errors
-        if isinstance(df.index, pd.DatetimeIndex):
-            if df.index.tz is not None:
-                df.index = df.index.tz_convert("UTC").tz_localize(None)
-            df.index = df.index.normalize()
-
         # --- Merge Sector Performance ---
         if self.sector_perf_df is not None and not self.sector_perf_df.empty:
             sector_df = self.sector_perf_df.copy()
             if "date" in sector_df.columns:
-                sector_df["date"] = pd.to_datetime(sector_df["date"])
-                sector_df.set_index("date", inplace=True)
-
-                if isinstance(sector_df.index, pd.DatetimeIndex):
-                    if sector_df.index.tz is not None:
-                        sector_df.index = sector_df.index.tz_convert("UTC").tz_localize(None)
-                    sector_df.index = sector_df.index.normalize()
-
-                # Keep numeric columns only for performance metrics
                 numeric_cols = sector_df.select_dtypes(include=["number"]).columns
-                sector_df = sector_df[numeric_cols]
-
-                # Add prefix
-                sector_df = sector_df.add_prefix("sector_")
-
-                # Join
-                df = df.join(sector_df, how="left")
+                sector_payload = sector_df[["date", *numeric_cols]]
+                df, added_columns = merge_asof_features(
+                    df,
+                    sector_payload,
+                    feature_date_column="date",
+                    prefix="sector_",
+                )
+                metadata.add_optional_columns(added_columns)
 
         # --- Merge Industry Performance ---
         if self.industry_perf_df is not None and not self.industry_perf_df.empty:
             ind_df = self.industry_perf_df.copy()
             if "date" in ind_df.columns:
-                ind_df["date"] = pd.to_datetime(ind_df["date"])
-                ind_df.set_index("date", inplace=True)
-
-                if isinstance(ind_df.index, pd.DatetimeIndex):
-                    if ind_df.index.tz is not None:
-                        ind_df.index = ind_df.index.tz_convert("UTC").tz_localize(None)
-                    ind_df.index = ind_df.index.normalize()
-
                 numeric_cols = ind_df.select_dtypes(include=["number"]).columns
-                ind_df = ind_df[numeric_cols]
-
-                ind_df = ind_df.add_prefix("industry_")
-
-                df = df.join(ind_df, how="left")
-
-        # Restore index if we changed it temporarily
-        if temp_index and date_col:
-            df.reset_index(inplace=True)
+                industry_payload = ind_df[["date", *numeric_cols]]
+                df, added_columns = merge_asof_features(
+                    df,
+                    industry_payload,
+                    feature_date_column="date",
+                    prefix="industry_",
+                )
+                metadata.add_optional_columns(added_columns)
 
         return df
 

--- a/src/quantrl_lab/data/processing/steps/features/cross_sectional.py
+++ b/src/quantrl_lab/data/processing/steps/features/cross_sectional.py
@@ -3,11 +3,9 @@
 from typing import List, Optional
 
 import pandas as pd
-from rich.console import Console
+from loguru import logger
 
-from quantrl_lab.data.processing.processor import ProcessingMetadata
-
-console = Console()
+from quantrl_lab.data.processing.metadata import ProcessingMetadata
 
 
 class CrossSectionalStep:
@@ -61,11 +59,11 @@ class CrossSectionalStep:
             return data
 
         if "Symbol" not in data.columns:
-            console.print("[yellow]⚠️ CrossSectionalStep requires a 'Symbol' column. Skipping.[/yellow]")
+            logger.warning("CrossSectionalStep requires a 'Symbol' column. Skipping.")
             return data
 
         if data["Symbol"].nunique() < 2:
-            console.print("[dim]CrossSectionalStep bypassed: Only 1 symbol present in data.[/dim]")
+            logger.debug("CrossSectionalStep bypassed because only one symbol is present.")
             return data
 
         result = data.copy()
@@ -76,7 +74,7 @@ class CrossSectionalStep:
 
         for col in self.columns:
             if col not in result.columns:
-                console.print(f"[yellow]⚠️ Column '{col}' not found for cross-sectional processing.[/yellow]")
+                logger.warning("Column '{column}' not found for cross-sectional processing.", column=col)
                 continue
 
             for method in self.methods:
@@ -93,7 +91,13 @@ class CrossSectionalStep:
                     result[new_col_name] = grouped[col].transform(lambda x: x - x.mean())
 
         # Update metadata to track these new features
-        metadata.cross_sectional_features.extend([f"{c}_cs_{m}" for c in self.columns for m in self.methods])
+        generated_columns = [
+            f"{c}_cs_{m}" for c in self.columns for m in self.methods if f"{c}_cs_{m}" in result.columns
+        ]
+        metadata.cross_sectional_features.extend(
+            [column for column in generated_columns if column not in metadata.cross_sectional_features]
+        )
+        metadata.add_required_columns(generated_columns)
 
         return result
 

--- a/src/quantrl_lab/data/processing/steps/features/technical.py
+++ b/src/quantrl_lab/data/processing/steps/features/technical.py
@@ -3,12 +3,10 @@
 from typing import Dict, List, Optional, Union
 
 import pandas as pd
-from rich.console import Console
+from loguru import logger
 
 from quantrl_lab.data.processing.features.technical import TechnicalFeatureGenerator
-from quantrl_lab.data.processing.processor import ProcessingMetadata
-
-console = Console()
+from quantrl_lab.data.processing.metadata import ProcessingMetadata
 
 
 class TechnicalIndicatorStep:
@@ -51,19 +49,14 @@ class TechnicalIndicatorStep:
         if not self.indicators:
             return data.copy()
 
-        try:
-            generator = TechnicalFeatureGenerator(self.indicators)
-            result = generator.generate(data)
+        generator = TechnicalFeatureGenerator(self.indicators)
+        result = generator.generate(data)
 
-            # Update metadata
-            metadata.technical_indicators = self.indicators
+        metadata.technical_indicators = self.indicators
+        metadata.add_required_columns([col for col in result.columns if col not in data.columns])
+        logger.debug("Applied technical indicators: {indicators}", indicators=self.indicators)
 
-            return result
-        except ValueError as e:
-            raise e
-        except Exception as e:
-            console.print(f"[red]❌ Failed to apply technical indicators: {e}[/red]")
-            return data.copy()
+        return result
 
     def get_step_name(self) -> str:
         """Return step name."""

--- a/src/quantrl_lab/data/source_registry.py
+++ b/src/quantrl_lab/data/source_registry.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import pandas as pd
 
@@ -59,6 +59,7 @@ class DataSourceRegistry:
         """
         # Internal storage
         self._factories: Dict[str, Callable] = {}  # name -> factory function
+        self._capabilities: Dict[str, Set[str]] = {}  # name -> declared capability set
         self._sources: Dict[str, Any] = {}  # name -> instantiated source (lazy)
 
         # Register default sources
@@ -68,18 +69,32 @@ class DataSourceRegistry:
         if sources:
             for name, source_class in sources.items():
                 if source_class is not None:
-                    self.register_source(name, self._make_factory(source_class), override=True)
+                    self.register_source(
+                        name,
+                        self._make_factory(source_class),
+                        override=True,
+                        capabilities=getattr(source_class, "SUPPORTED_FEATURES", set()),
+                    )
 
         # Override with kwargs (backward compatibility)
         for name, source_class in kwargs.items():
             if source_class is not None:
-                self.register_source(name, self._make_factory(source_class), override=True)
+                self.register_source(
+                    name,
+                    self._make_factory(source_class),
+                    override=True,
+                    capabilities=getattr(source_class, "SUPPORTED_FEATURES", set()),
+                )
 
     def _register_defaults(self) -> None:
         """Register default data sources."""
         for name, source_class in self.DEFAULT_SOURCES.items():
             if source_class is not None:
-                self.register_source(name, self._make_factory(source_class))
+                self.register_source(
+                    name,
+                    self._make_factory(source_class),
+                    capabilities=getattr(source_class, "SUPPORTED_FEATURES", set()),
+                )
 
     @staticmethod
     def _make_factory(source_class: type) -> Callable:
@@ -96,9 +111,17 @@ class DataSourceRegistry:
         def factory(**init_kwargs):
             return source_class(**init_kwargs)
 
+        factory.source_class = source_class
+        factory.supported_features = set(getattr(source_class, "SUPPORTED_FEATURES", set()))
         return factory
 
-    def register_source(self, name: str, factory: Callable, override: bool = False) -> None:
+    def register_source(
+        self,
+        name: str,
+        factory: Callable,
+        override: bool = False,
+        capabilities: Optional[Set[str]] = None,
+    ) -> None:
         """
         Register a data source factory.
 
@@ -106,6 +129,7 @@ class DataSourceRegistry:
             name: Unique name for this source (e.g., "alpaca_primary", "yfinance_backup")
             factory: Callable that returns a data source instance
             override: If True, replace existing registration
+            capabilities: Explicit capability set used for source discovery
 
         Raises:
             ValueError: If source already registered and override=False
@@ -117,6 +141,33 @@ class DataSourceRegistry:
         if name in self._factories and not override:
             raise ValueError(f"Source '{name}' already registered. Use override=True to replace.")
         self._factories[name] = factory
+        self._capabilities[name] = self._resolve_capabilities(factory, capabilities)
+
+    @staticmethod
+    def _resolve_capabilities(factory: Callable, capabilities: Optional[Set[str]]) -> Set[str]:
+        """Resolve capability metadata without forcing callers to
+        provide it explicitly."""
+        if capabilities is not None:
+            return set(capabilities)
+
+        factory_features = getattr(factory, "supported_features", None)
+        if factory_features is not None:
+            return set(factory_features)
+
+        source_class = getattr(factory, "source_class", None)
+        if source_class is not None:
+            return set(getattr(source_class, "SUPPORTED_FEATURES", set()))
+
+        try:
+            instance = factory()
+        except Exception:
+            return set()
+
+        instance_features = getattr(instance, "supported_features", None)
+        if instance_features is not None:
+            return set(instance_features)
+
+        return set(getattr(instance.__class__, "SUPPORTED_FEATURES", set()))
 
     def get_source(self, name: str, **init_kwargs: Any) -> Any:
         """
@@ -157,16 +208,7 @@ class DataSourceRegistry:
             >>> sources = registry.list_sources_by_capability("historical_bars")
             >>> print(sources)  # ["primary_source", "backup_source"]
         """
-        results = []
-        for name in self._factories:
-            try:
-                source = self.get_source(name)
-                if source.supports_feature(capability):
-                    results.append(name)
-            except Exception:
-                # Skip sources that fail to instantiate
-                continue
-        return results
+        return [name for name, features in self._capabilities.items() if capability in features]
 
     def list_all_sources(self) -> List[str]:
         """

--- a/src/quantrl_lab/data/sources/alpaca_loader.py
+++ b/src/quantrl_lab/data/sources/alpaca_loader.py
@@ -6,7 +6,6 @@ if TYPE_CHECKING:
     import aiohttp
 
 import pandas as pd
-import requests
 from alpaca.data import StockHistoricalDataClient
 from alpaca.data.live import StockDataStream
 from alpaca.data.models import Trade
@@ -17,7 +16,7 @@ from alpaca.data.requests import (
 )
 from loguru import logger
 
-from quantrl_lab.data.exceptions import AuthenticationError, InvalidParametersError
+from quantrl_lab.data.exceptions import AuthenticationError, DataSourceError, InvalidParametersError
 from quantrl_lab.data.interface import (
     ConnectionManaged,
     DataSource,
@@ -28,6 +27,8 @@ from quantrl_lab.data.interface import (
 )
 from quantrl_lab.data.processing.mappings import ALPACA_MAPPINGS
 from quantrl_lab.data.utils import (
+    HTTPRequestWrapper,
+    RetryStrategy,
     add_date_column_from_timestamp,
     format_date_to_string,
     log_dataframe_info,
@@ -47,6 +48,14 @@ class AlpacaDataLoader(
 ):
     """Alpaca implementation that provides market data from Alpaca
     APIs."""
+
+    SUPPORTED_FEATURES = {
+        "historical_bars",
+        "live_data",
+        "streaming",
+        "news",
+        "connection_managed",
+    }
 
     NEWS_API_BASE_URL = "https://data.alpaca.markets/v1beta1/news"
     DEFAULT_NEWS_SORT = "desc"
@@ -73,6 +82,12 @@ class AlpacaDataLoader(
         if AlpacaDataLoader._stock_stream_client_instance is None:
             AlpacaDataLoader._stock_stream_client_instance = StockDataStream(self.api_key, self.secret_key)
         self.stock_stream_client = AlpacaDataLoader._stock_stream_client_instance
+        self._news_request_wrapper = HTTPRequestWrapper(
+            max_retries=3,
+            retry_strategy=RetryStrategy.EXPONENTIAL,
+            base_delay=1.0,
+            timeout=30.0,
+        )
 
         self.subscribers = {"quotes": [], "trades": [], "bars": []}
         self._subscribed_symbols = set()
@@ -120,8 +135,8 @@ class AlpacaDataLoader(
         market: Optional[str] = None,
         **kwargs,
     ) -> List[str]:
-        # TODO
-        pass
+        logger.warning("AlpacaDataLoader does not currently implement instrument discovery.")
+        return []
 
     def get_historical_ohlcv_data(
         self,
@@ -334,10 +349,12 @@ class AlpacaDataLoader(
                 params["page_token"] = page_token
 
             try:
-                response = requests.get(self.NEWS_API_BASE_URL, headers=headers, params=params)
-                response.raise_for_status()
-
-                data = response.json()
+                data = self._news_request_wrapper.make_request(
+                    self.NEWS_API_BASE_URL,
+                    headers=headers,
+                    params=params,
+                    raise_on_error=True,
+                )
                 news_items = data.get("news", [])
 
                 if not news_items:
@@ -357,12 +374,11 @@ class AlpacaDataLoader(
                 if not page_token:
                     break
 
-            except requests.exceptions.RequestException as e:
+            except DataSourceError as e:
                 if silent_errors:
                     logger.debug("Silent failure fetching news: {e}", e=e)
-                else:
-                    logger.error("Error fetching news: {e}", e=e)
-                break
+                    return pd.DataFrame()
+                raise
 
         if verbose:
             logger.success("Total news items fetched: {n}", n=len(all_news))

--- a/src/quantrl_lab/data/sources/alpha_vantage_loader.py
+++ b/src/quantrl_lab/data/sources/alpha_vantage_loader.py
@@ -1,10 +1,8 @@
 import os
-import time
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
-import requests
 from loguru import logger
 
 from quantrl_lab.data.config import (
@@ -12,7 +10,7 @@ from quantrl_lab.data.config import (
     FundamentalMetric,
     MacroIndicator,
 )
-from quantrl_lab.data.exceptions import InvalidParametersError
+from quantrl_lab.data.exceptions import APIConnectionError, AuthenticationError, InvalidParametersError, RateLimitError
 from quantrl_lab.data.interface import (
     DataSource,
     FundamentalDataCapable,
@@ -22,10 +20,13 @@ from quantrl_lab.data.interface import (
 )
 from quantrl_lab.data.processing.mappings import ALPHA_VANTAGE_COLUMN_MAPPER
 from quantrl_lab.data.utils import (
+    HTTPRequestWrapper,
+    RetryStrategy,
     convert_columns_to_numeric,
     format_av_datetime,
     log_dataframe_info,
     normalize_date_range,
+    normalize_symbols,
 )
 
 
@@ -37,6 +38,8 @@ class AlphaVantageDataLoader(
     NewsDataCapable,
 ):
     """Alpha Vantage implementation that provides various datasets."""
+
+    SUPPORTED_FEATURES = {"historical_bars", "fundamental_data", "macro_data", "news"}
 
     DEFAULT_MAX_RETRIES = 3
     DEFAULT_RETRY_DELAY = 5
@@ -54,7 +57,13 @@ class AlphaVantageDataLoader(
         self.max_retries = max_retries
         self.delay = delay
         self.rate_limit_delay = rate_limit_delay
-        self._last_request_time: float = 0
+        self._request_wrapper = HTTPRequestWrapper(
+            max_retries=max_retries,
+            retry_strategy=RetryStrategy.EXPONENTIAL,
+            base_delay=float(delay),
+            rate_limit_delay=rate_limit_delay,
+            timeout=30.0,
+        )
 
     @property
     def source_name(self) -> str:
@@ -361,10 +370,8 @@ class AlphaVantageDataLoader(
             end = datetime.now()
         time_to = format_av_datetime(end)
 
-        if isinstance(symbols, str):
-            tickers = symbols
-        else:
-            tickers = ",".join(symbols)
+        symbol_list = normalize_symbols(symbols)
+        tickers = ",".join(symbol_list)
 
         logger.info(f"Fetching news for {tickers} from {time_from} to {time_to}")
 
@@ -390,9 +397,7 @@ class AlphaVantageDataLoader(
         news_df = pd.DataFrame(news_data["feed"]) if news_data and "feed" in news_data else pd.DataFrame()
 
         if news_df.empty:
-            logger.warning(
-                f"No news data retrieved for {tickers}. This may be due to rate limits or no data available."
-            )
+            logger.warning(f"No news data retrieved for {tickers}. This may be due to no data being available.")
             return news_df
 
         if "time_published" in news_df.columns:
@@ -402,45 +407,67 @@ class AlphaVantageDataLoader(
             logger.debug(f"Available columns: {list(news_df.columns)}")
             return pd.DataFrame()
 
-        try:
-            news_df["created_at"] = pd.to_datetime(news_df["created_at"], format="%Y%m%dT%H%M%S")
-            news_df["Date"] = news_df["created_at"].dt.date
-        except Exception as e:
-            logger.error(f"Failed to parse news timestamps for {tickers}: {e}")
-            return pd.DataFrame()
-
-        if "ticker_sentiment" in news_df.columns:
-            try:
-                news_df["sentiment_score"] = (
-                    news_df["ticker_sentiment"].apply(lambda x: self._find_ticker_sentiment(x, tickers)).astype(float)
-                )
-            except Exception as e:
-                logger.warning(f"Failed to extract sentiment scores for {tickers}: {e}")
+        news_df["created_at"] = pd.to_datetime(news_df["created_at"], format="%Y%m%dT%H%M%S")
+        news_df["Date"] = news_df["created_at"].dt.date
+        news_df = self._expand_news_rows(news_df, symbol_list)
 
         logger.success(f"Retrieved {len(news_df)} news items for {tickers}")
 
         return news_df
 
-    def _find_ticker_sentiment(self, sentiment_list: List[Dict], ticker_symbol: str) -> Optional[float]:
-        """
-        Find the sentiment score for a specific ticker in the sentiment
-        list.
+    def _expand_news_rows(self, news_df: pd.DataFrame, requested_symbols: List[str]) -> pd.DataFrame:
+        """Normalize Alpha Vantage news into one row per article-symbol
+        pair."""
+        if "ticker_sentiment" not in news_df.columns:
+            result = news_df.copy()
+            if len(requested_symbols) == 1:
+                result["Symbol"] = requested_symbols[0]
+            return result
 
-        Args:
-            sentiment_list (List[Dict]): A list of dictionaries containing sentiments
-                for different tickers.
-            ticker_symbol (str): The ticker symbol to search for (e.g., 'AAPL').
+        expanded_rows: List[pd.Series] = []
+        for _, row in news_df.iterrows():
+            sentiment_map = self._extract_ticker_sentiments(row.get("ticker_sentiment"), requested_symbols)
+            if sentiment_map:
+                for symbol, score in sentiment_map.items():
+                    row_copy = row.copy()
+                    row_copy["Symbol"] = symbol
+                    row_copy["sentiment_score"] = score
+                    expanded_rows.append(row_copy)
+            elif len(requested_symbols) == 1:
+                row_copy = row.copy()
+                row_copy["Symbol"] = requested_symbols[0]
+                row_copy["sentiment_score"] = None
+                expanded_rows.append(row_copy)
 
-        Returns:
-            Optional[float]: The sentiment score for the specified ticker, or None if not found.
-        """
+        if not expanded_rows:
+            return pd.DataFrame(columns=list(news_df.columns) + ["Symbol", "sentiment_score"])
+
+        return pd.DataFrame(expanded_rows).reset_index(drop=True)
+
+    @staticmethod
+    def _extract_ticker_sentiments(
+        sentiment_list: List[Dict[str, Any]],
+        requested_symbols: List[str],
+    ) -> Dict[str, Optional[float]]:
+        """Extract per-symbol sentiment scores for the requested
+        tickers."""
         if not isinstance(sentiment_list, list):
-            return None
+            return {}
 
+        requested = set(requested_symbols)
+        matches: Dict[str, Optional[float]] = {}
         for item in sentiment_list:
-            if item.get("ticker") == ticker_symbol:
-                return item["ticker_sentiment_score"]
-        return None
+            ticker = item.get("ticker")
+            if ticker not in requested:
+                continue
+
+            score = item.get("ticker_sentiment_score")
+            try:
+                matches[ticker] = float(score) if score is not None else None
+            except (TypeError, ValueError):
+                matches[ticker] = None
+
+        return matches
 
     def get_macro_data(
         self,
@@ -646,10 +673,8 @@ class AlphaVantageDataLoader(
         Returns:
             Optional[Dict[str, Any]]: Parsed JSON response, or None if all retries are exhausted.
         """
-        elapsed = time.time() - self._last_request_time
-        if elapsed < self.rate_limit_delay:
-            sleep_time = self.rate_limit_delay - elapsed
-            time.sleep(sleep_time)
+        if not self.api_key:
+            raise AuthenticationError("Alpha Vantage API key not provided")
 
         url_params = {
             "function": function,
@@ -660,76 +685,50 @@ class AlphaVantageDataLoader(
         if symbol:
             url_params["symbol"] = symbol
 
-        for attempt in range(self.max_retries):
-            try:
-                self._last_request_time = time.time()
-                response = requests.get(ALPHA_VANTAGE_API_BASE, params=url_params, timeout=30)
+        data = self._request_wrapper.make_request(
+            ALPHA_VANTAGE_API_BASE,
+            params=url_params,
+            raise_on_error=True,
+        )
 
-                if response.status_code == 200:
-                    data = response.json()
+        if not isinstance(data, dict):
+            raise APIConnectionError(f"Unexpected response while fetching {function} data")
 
-                    if "Error Message" in data:
-                        error_msg = f"API Error: {data['Error Message']}"
-                        if symbol:
-                            error_msg += f" for {symbol}"
-                        logger.error(error_msg)
-                        return None
+        if "Error Message" in data:
+            error_msg = f"API Error: {data['Error Message']}"
+            if symbol:
+                error_msg += f" for {symbol}"
+            raise InvalidParametersError(error_msg)
 
-                    if "Information" in data:
-                        logger.warning(f"API Information message: {data['Information']}")
-                        return data
+        if "Note" in data and "api call frequency" in data.get("Note", "").lower():
+            error_msg = data["Note"]
+            if symbol:
+                error_msg = f"{error_msg} for {symbol}"
+            raise RateLimitError(error_msg)
 
-                    if "Note" in data and "API call frequency" in data.get("Note", ""):
-                        warning_msg = "Rate limit hit"
-                        if symbol:
-                            warning_msg += f" for {symbol}"
-                        logger.warning(f"{warning_msg}, retrying...")
+        if "Information" in data:
+            info_message = data["Information"]
+            lowered = info_message.lower()
+            if any(
+                indicator in lowered
+                for indicator in [
+                    "request per second",
+                    "requests per day",
+                    "rate limit",
+                    "api call frequency",
+                    "thank you for using alpha vantage",
+                ]
+            ):
+                raise RateLimitError(info_message)
+            if "api key" in lowered or "unauthorized" in lowered:
+                raise AuthenticationError(info_message)
+            raise APIConnectionError(info_message)
 
-                        if attempt < self.max_retries - 1:
-                            wait_time = self.delay * (2**attempt)
-                            time.sleep(wait_time)
-                            continue
-                        return None
-
-                    success_msg = f"Successfully fetched {function} data"
-                    if symbol:
-                        success_msg += f" for {symbol}"
-                    logger.info(success_msg)
-                    return data
-
-                elif response.status_code == 429:
-                    if attempt < self.max_retries - 1:
-                        wait_time = self.delay * (2**attempt)
-                        logger.warning(f"Rate limited, waiting {wait_time}s before retry...")
-                        time.sleep(wait_time)
-                        continue
-
-                response.raise_for_status()
-
-            except requests.exceptions.Timeout:
-                timeout_msg = f"Timeout (attempt {attempt + 1})"
-                if symbol:
-                    timeout_msg = f"Timeout for {symbol} (attempt {attempt + 1})"
-                logger.warning(timeout_msg)
-            except requests.exceptions.ConnectionError:
-                conn_msg = f"Connection error (attempt {attempt + 1})"
-                if symbol:
-                    conn_msg = f"Connection error for {symbol} (attempt {attempt + 1})"
-                logger.warning(conn_msg)
-            except requests.exceptions.RequestException as e:
-                req_msg = f"Request error: {e} (attempt {attempt + 1})"
-                if symbol:
-                    req_msg = f"Request error for {symbol}: {e} (attempt {attempt + 1})"
-                logger.warning(req_msg)
-
-            if attempt < self.max_retries - 1:
-                time.sleep(self.delay * (attempt + 1))
-
-        error_msg = f"Failed to fetch {function} data after {self.max_retries} attempts"
+        success_msg = f"Successfully fetched {function} data"
         if symbol:
-            error_msg = f"Failed to fetch {function} data for {symbol} after {self.max_retries} attempts"
-        logger.error(error_msg)
-        return None
+            success_msg += f" for {symbol}"
+        logger.info(success_msg)
+        return data
 
     def _get_company_overview(self, symbol: str) -> Optional[Dict[str, Any]]:
         """

--- a/src/quantrl_lab/data/sources/fmp_loader.py
+++ b/src/quantrl_lab/data/sources/fmp_loader.py
@@ -53,6 +53,8 @@ class FMPDataSource(
     - CompanyProfileCapable: Company profile and metadata
     """
 
+    SUPPORTED_FEATURES = {"historical_bars", "analyst_data", "sector_data", "company_profile"}
+
     BASE_URL = "https://financialmodelingprep.com/stable"
     RATE_LIMIT_SLEEP = 1  # seconds
     INTRADAY_TIMEFRAMES = {"5min", "15min", "30min", "1hour", "4hour"}

--- a/src/quantrl_lab/data/sources/yfinance_loader.py
+++ b/src/quantrl_lab/data/sources/yfinance_loader.py
@@ -11,7 +11,7 @@ from quantrl_lab.data.config import (
     YFinanceInterval,
     financial_columns,
 )
-from quantrl_lab.data.exceptions import InvalidParametersError
+from quantrl_lab.data.exceptions import APIConnectionError, InvalidParametersError
 from quantrl_lab.data.interface import (
     DataSource,
     FundamentalDataCapable,
@@ -23,6 +23,8 @@ from quantrl_lab.data.utils import log_dataframe_info, normalize_date_range, nor
 class YFinanceDataLoader(DataSource, FundamentalDataCapable, HistoricalDataCapable):
     """Yahoo Finance implementation that provides market data and
     fundamental data."""
+
+    SUPPORTED_FEATURES = {"historical_bars", "fundamental_data"}
 
     def __init__(
         self,
@@ -55,8 +57,8 @@ class YFinanceDataLoader(DataSource, FundamentalDataCapable, HistoricalDataCapab
         market: Optional[str] = None,
         **kwargs,
     ) -> List[str]:
-        # TODO
-        pass
+        logger.warning("Yahoo Finance does not support listing available instruments.")
+        return []
 
     def get_fundamental_data(
         self,
@@ -193,24 +195,30 @@ class YFinanceDataLoader(DataSource, FundamentalDataCapable, HistoricalDataCapab
             logger.warning("Neither 'start' nor 'period' provided. Defaulting to period='1mo'")
             period = "1mo"
 
+        last_error: Optional[Exception] = None
         for attempt in range(self.max_retries):
             try:
-                result = pd.DataFrame()
-                for symbol in symbol_list:
-                    ticker = yf.Ticker(symbol)
-                    if start_dt is not None:
-                        data = ticker.history(start=start_dt, end=end_dt, interval=timeframe, **kwargs).assign(
-                            Symbol=symbol
-                        )
-                    else:
-                        data = ticker.history(period=period, interval=timeframe, **kwargs).assign(Symbol=symbol)
-                    result = pd.concat([result, data])
+                download_kwargs = {
+                    "interval": timeframe,
+                    "group_by": "column",
+                    "auto_adjust": False,
+                    "progress": False,
+                    "threads": len(symbol_list) > 1,
+                    **kwargs,
+                }
+                if start_dt is not None:
+                    download_kwargs["start"] = start_dt
+                    download_kwargs["end"] = end_dt
+                else:
+                    download_kwargs["period"] = period
 
-                df_result = result.reset_index()
+                result = yf.download(symbol_list, **download_kwargs)
+                df_result = self._normalize_download_result(result, symbol_list)
                 log_dataframe_info(df_result, f"Fetched OHLCV data for {len(symbol_list)} symbol(s)")
                 return df_result
 
             except Exception as e:
+                last_error = e
                 if attempt < self.max_retries - 1:
                     logger.warning(
                         "Failed to fetch data for {symbols} (attempt {attempt}/{max_retries}): {error}",
@@ -227,7 +235,66 @@ class YFinanceDataLoader(DataSource, FundamentalDataCapable, HistoricalDataCapab
                         max_retries=self.max_retries,
                         error=str(e),
                     )
-                    return pd.DataFrame()
+                    raise APIConnectionError(
+                        f"Failed to fetch data for {symbol_list} after {self.max_retries} retries"
+                    ) from e
+
+        if last_error is not None:
+            raise APIConnectionError(f"Failed to fetch data for {symbol_list}") from last_error
+
+        return pd.DataFrame()
+
+    def _normalize_download_result(self, data: pd.DataFrame, symbol_list: List[str]) -> pd.DataFrame:
+        """Normalize `yf.download` output into the library's row-wise
+        format."""
+        if data is None or data.empty:
+            return pd.DataFrame()
+
+        if isinstance(data.columns, pd.MultiIndex):
+            symbol_level = self._detect_symbol_level(data.columns, symbol_list)
+            frames = []
+            for symbol in symbol_list:
+                if symbol not in data.columns.get_level_values(symbol_level):
+                    continue
+                symbol_frame = data.xs(symbol, axis=1, level=symbol_level, drop_level=True).copy()
+                normalized = self._normalize_single_result(symbol_frame.reset_index(), symbol)
+                if not normalized.empty:
+                    frames.append(normalized)
+
+            if not frames:
+                return pd.DataFrame()
+
+            return pd.concat(frames, ignore_index=True)
+
+        return self._normalize_single_result(data.reset_index(), symbol_list[0])
+
+    @staticmethod
+    def _detect_symbol_level(columns: pd.MultiIndex, symbol_list: List[str]) -> int:
+        """Detect which MultiIndex level corresponds to ticker
+        symbols."""
+        symbol_candidates = set(symbol_list)
+        for level in range(columns.nlevels):
+            if symbol_candidates.issubset(set(columns.get_level_values(level))):
+                return level
+        raise APIConnectionError("Unexpected yfinance column structure for multi-symbol download")
+
+    @staticmethod
+    def _normalize_single_result(df: pd.DataFrame, symbol: str) -> pd.DataFrame:
+        """Normalize a single-symbol history DataFrame."""
+        if df.empty:
+            return df
+
+        result = df.copy()
+        if "Datetime" in result.columns and "Date" not in result.columns:
+            result = result.rename(columns={"Datetime": "Date"})
+        elif "index" in result.columns and "Date" not in result.columns:
+            result = result.rename(columns={"index": "Date"})
+
+        result["Symbol"] = symbol
+        if "Date" in result.columns:
+            result = result.sort_values("Date").reset_index(drop=True)
+
+        return result
 
     def _fetch_single_symbol(
         self,

--- a/src/quantrl_lab/data/utils/__init__.py
+++ b/src/quantrl_lab/data/utils/__init__.py
@@ -7,6 +7,7 @@ from .dataframe_normalization import (
     standardize_ohlcv_columns,
     standardize_ohlcv_dataframe,
 )
+from .date_alignment import merge_asof_features, to_naive_datetime
 from .date_parsing import (
     format_av_datetime,
     format_date_to_string,
@@ -42,6 +43,8 @@ __all__ = [
     "standardize_ohlcv_dataframe",
     # Request utilities
     "AsyncHTTPRequestWrapper",
+    "merge_asof_features",
+    "to_naive_datetime",
     "HTTPRequestWrapper",
     "RetryStrategy",
     "create_default_wrapper",

--- a/src/quantrl_lab/data/utils/async_request_utils.py
+++ b/src/quantrl_lab/data/utils/async_request_utils.py
@@ -10,6 +10,8 @@ from typing import Any, Dict, List, Optional, Union
 
 from loguru import logger
 
+from quantrl_lab.data.exceptions import APIConnectionError, AuthenticationError, RateLimitError
+
 try:
     import aiohttp
 except ImportError as e:
@@ -62,6 +64,23 @@ class AsyncHTTPRequestWrapper:
             return any(indicator in body_text for indicator in RATE_LIMIT_INDICATORS)
         return False
 
+    def _is_auth_error(self, status: int, json_data: Optional[Any]) -> bool:
+        """Detect auth failures from HTTP status or response body."""
+        if status in {401, 403}:
+            return True
+        if json_data is None:
+            return False
+        body_text = str(json_data).lower()
+        auth_indicators = [
+            "unauthorized",
+            "forbidden",
+            "invalid api key",
+            "invalid token",
+            "authentication",
+            "permission",
+        ]
+        return any(indicator in body_text for indicator in auth_indicators)
+
     def _backoff_delay(self, attempt: int, rate_limited: bool = False) -> float:
         """Exponential backoff; doubles for rate limit errors."""
         delay = self.base_delay * (2**attempt)
@@ -113,6 +132,9 @@ class AsyncHTTPRequestWrapper:
                             logger.debug("Async request successful: {url}", url=url)
                             return json_data
 
+                        if self._is_auth_error(response.status, json_data):
+                            raise AuthenticationError(f"Authentication failed for {url}")
+
                         if attempt < self.max_retries:
                             delay = self._backoff_delay(attempt, rate_limited=is_rate_limit)
                             if is_rate_limit:
@@ -136,7 +158,11 @@ class AsyncHTTPRequestWrapper:
                                 url=url,
                                 status=response.status,
                             )
-                            return None
+                            if is_rate_limit:
+                                raise RateLimitError(f"Rate limit hit for {url}")
+                            raise APIConnectionError(
+                                f"Async request failed after {self.max_retries + 1} attempts: {url}"
+                            )
 
                 except asyncio.TimeoutError:
                     if attempt < self.max_retries:
@@ -147,7 +173,12 @@ class AsyncHTTPRequestWrapper:
                         logger.error(
                             "Async request timed out after {n} attempts: {url}", n=self.max_retries + 1, url=url
                         )
-                        return None
+                        raise APIConnectionError(
+                            f"Async request timed out after {self.max_retries + 1} attempts: {url}"
+                        )
+
+                except AuthenticationError:
+                    raise
 
                 except Exception as e:
                     if attempt < self.max_retries:
@@ -160,6 +191,10 @@ class AsyncHTTPRequestWrapper:
                         logger.error(
                             "Async request failed after {n} attempts: {url} — {e}", n=self.max_retries + 1, url=url, e=e
                         )
-                        return None
+                        if isinstance(e, RateLimitError):
+                            raise
+                        raise APIConnectionError(
+                            f"Async request failed after {self.max_retries + 1} attempts: {url}"
+                        ) from e
 
         return None

--- a/src/quantrl_lab/data/utils/date_alignment.py
+++ b/src/quantrl_lab/data/utils/date_alignment.py
@@ -1,0 +1,108 @@
+"""Helpers for aligning sparse feature data to market data
+timestamps."""
+
+from typing import Iterable, List, Optional, Tuple
+
+import pandas as pd
+
+DATE_COLUMN_CANDIDATES = ("Timestamp", "Date", "date")
+
+
+def to_naive_datetime(series: pd.Series) -> pd.Series:
+    """Convert arbitrary date-like values to timezone-naive
+    datetimes."""
+    dt_series = pd.to_datetime(series)
+    if getattr(dt_series.dt, "tz", None) is not None:
+        dt_series = dt_series.dt.tz_convert("UTC").dt.tz_localize(None)
+    return dt_series
+
+
+def merge_asof_features(
+    base_df: pd.DataFrame,
+    feature_df: pd.DataFrame,
+    *,
+    feature_date_column: str,
+    drop_columns: Iterable[str] = (),
+    prefix: str = "",
+    base_by_columns: Iterable[str] = (),
+    feature_by_columns: Optional[Iterable[str]] = None,
+) -> Tuple[pd.DataFrame, List[str]]:
+    """
+    Backward-align sparse feature data to the base market-data timeline.
+
+    Returns the merged DataFrame plus the list of feature columns that
+    were added.
+    """
+    if feature_df is None or feature_df.empty:
+        return base_df.copy(), []
+
+    base_working, base_date_column, restore_index = _prepare_base_frame(base_df)
+    if feature_date_column not in feature_df.columns:
+        return base_df.copy(), []
+
+    base_group_columns = list(base_by_columns)
+    feature_group_columns = list(feature_by_columns) if feature_by_columns is not None else list(base_group_columns)
+    if len(base_group_columns) != len(feature_group_columns):
+        raise ValueError("base_by_columns and feature_by_columns must have the same length")
+
+    for column in base_group_columns:
+        if column not in base_working.columns:
+            return base_df.copy(), []
+    for column in feature_group_columns:
+        if column not in feature_df.columns:
+            return base_df.copy(), []
+
+    feature_working = feature_df.copy()
+    feature_working["__merge_date__"] = to_naive_datetime(feature_working[feature_date_column])
+
+    excluded = set(drop_columns)
+    excluded.add(feature_date_column)
+    excluded.update(feature_group_columns)
+    feature_columns = [col for col in feature_working.columns if col not in excluded and col != "__merge_date__"]
+    if not feature_columns:
+        return base_df.copy(), []
+
+    rename_map = {col: f"{prefix}{col}" for col in feature_columns}
+    group_rename_map = {
+        source: target for source, target in zip(feature_group_columns, base_group_columns) if source != target
+    }
+    payload = feature_working[["__merge_date__", *feature_group_columns, *feature_columns]].rename(
+        columns={**rename_map, **group_rename_map}
+    )
+    sort_columns = [*base_group_columns, "__merge_date__"] if base_group_columns else ["__merge_date__"]
+    payload = payload.sort_values(sort_columns).reset_index(drop=True)
+
+    base_working["__merge_date__"] = to_naive_datetime(base_working[base_date_column])
+    base_working["__row_order__"] = range(len(base_working))
+    base_sorted = base_working.sort_values(sort_columns).reset_index(drop=True)
+
+    merge_kwargs = {"on": "__merge_date__", "direction": "backward"}
+    if base_group_columns:
+        merge_kwargs["by"] = base_group_columns
+
+    merged = pd.merge_asof(base_sorted, payload, **merge_kwargs)
+    merged = merged.sort_values("__row_order__").drop(columns=["__merge_date__", "__row_order__"])
+
+    if restore_index:
+        merged = merged.set_index(base_date_column)
+        merged.index.name = base_df.index.name
+
+    return merged, list(rename_map.values())
+
+
+def _prepare_base_frame(base_df: pd.DataFrame) -> Tuple[pd.DataFrame, str, bool]:
+    """Prepare the base DataFrame for date-based alignment."""
+    if isinstance(base_df.index, pd.DatetimeIndex):
+        base_working = base_df.reset_index()
+        base_date_column = base_df.index.name or "index"
+        if base_working.columns[0] != base_date_column:
+            base_working = base_working.rename(columns={base_working.columns[0]: base_date_column})
+        return base_working, base_date_column, True
+
+    for column in DATE_COLUMN_CANDIDATES:
+        if column in base_df.columns:
+            return base_df.copy(), column, False
+
+    raise ValueError(
+        "DataFrame must contain a DatetimeIndex or one of the date columns: " f"{', '.join(DATE_COLUMN_CANDIDATES)}"
+    )

--- a/src/quantrl_lab/data/utils/request_utils.py
+++ b/src/quantrl_lab/data/utils/request_utils.py
@@ -13,6 +13,8 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import requests
 from loguru import logger
 
+from quantrl_lab.data.exceptions import APIConnectionError, AuthenticationError, RateLimitError
+
 
 class RetryStrategy(Enum):
     """Retry strategy types."""
@@ -113,6 +115,55 @@ class HTTPRequestWrapper:
 
         return False
 
+    def _is_auth_error(self, response: requests.Response, json_data: Optional[Any] = None) -> bool:
+        """Detect authentication and authorization failures."""
+        if response.status_code in {401, 403}:
+            return True
+
+        if json_data is not None:
+            error_text = str(json_data).lower()
+            auth_indicators = [
+                "unauthorized",
+                "forbidden",
+                "invalid api key",
+                "invalid token",
+                "authentication",
+                "permission",
+                "not authenticated",
+            ]
+            return any(indicator in error_text for indicator in auth_indicators)
+
+        return False
+
+    @staticmethod
+    def _retry_after_seconds(response: requests.Response) -> Optional[int]:
+        """Parse Retry-After header when present."""
+        retry_after = response.headers.get("Retry-After")
+        if retry_after is None:
+            return None
+
+        try:
+            return int(retry_after)
+        except (TypeError, ValueError):
+            return None
+
+    def _build_http_exception(
+        self,
+        response: requests.Response,
+        json_data: Optional[Any] = None,
+    ) -> APIConnectionError:
+        """Map an HTTP response to a domain-specific exception."""
+        status_code = response.status_code
+        message = f"HTTP {status_code} error while requesting {response.url}"
+
+        if self._is_auth_error(response, json_data):
+            return AuthenticationError(message)
+
+        if self._is_rate_limit_error(response, json_data):
+            return RateLimitError(message, retry_after=self._retry_after_seconds(response))
+
+        return APIConnectionError(message)
+
     def make_request(
         self,
         url: str,
@@ -143,7 +194,7 @@ class HTTPRequestWrapper:
             Any: Parsed JSON response
 
         Raises:
-            requests.HTTPError: If raise_on_error=True and request fails
+            APIConnectionError: If raise_on_error=True and request fails
             ValueError: If custom_error_check detects an error
 
         Examples:
@@ -173,27 +224,35 @@ class HTTPRequestWrapper:
                 # Update last request time
                 self._last_request_time = time.time()
 
-                # Check for HTTP errors
-                response.raise_for_status()
-
                 # Parse JSON
                 try:
                     json_data = response.json()
                 except ValueError:
-                    # Not JSON, return text
-                    return response.text
+                    json_data = None
+
+                if response.status_code >= 400:
+                    raise self._build_http_exception(response, json_data)
 
                 # Custom error checking
                 if custom_error_check and custom_error_check(json_data):
                     raise ValueError(f"Custom error check failed for response: {json_data}")
 
                 # Success
+                if json_data is None:
+                    logger.debug(f"Request successful: {len(response.text)} bytes (text)")
+                    return response.text
+
                 logger.debug(f"Request successful: {len(str(json_data))} bytes")
                 return json_data
 
-            except requests.exceptions.HTTPError as e:
-                # Check if rate limit error
-                is_rate_limit = self._is_rate_limit_error(e.response, None)
+            except (AuthenticationError, RateLimitError, APIConnectionError) as e:
+                if isinstance(e, AuthenticationError):
+                    logger.error(f"Authentication failed: {e}")
+                    if raise_on_error:
+                        raise
+                    return None
+
+                is_rate_limit = isinstance(e, RateLimitError)
 
                 if attempt < self.max_retries:
                     delay = self._calculate_retry_delay(attempt)
@@ -201,11 +260,9 @@ class HTTPRequestWrapper:
                     # Extra delay for rate limit errors
                     if is_rate_limit:
                         delay *= rate_limit_retry_multiplier
-                        logger.warning(
-                            f"Rate limit hit (HTTP {e.response.status_code}). " f"Retrying in {delay:.2f}s..."
-                        )
+                        logger.warning(f"Rate limit hit. Retrying in {delay:.2f}s...")
                     else:
-                        logger.warning(f"HTTP error {e.response.status_code}: {e}. " f"Retrying in {delay:.2f}s...")
+                        logger.warning(f"Request failed: {e}. Retrying in {delay:.2f}s...")
 
                     time.sleep(delay)
                     attempt += 1
@@ -224,7 +281,7 @@ class HTTPRequestWrapper:
                 else:
                     logger.error(f"Request failed after {self.max_retries + 1} attempts: {e}")
                     if raise_on_error:
-                        raise
+                        raise APIConnectionError(f"Request failed after {self.max_retries + 1} attempts: {e}") from e
                     return None
 
             except Exception as e:

--- a/tests/data/partitioning/test_ratio_splitter.py
+++ b/tests/data/partitioning/test_ratio_splitter.py
@@ -19,10 +19,10 @@ class TestRatioSplitterInit:
         splitter = RatioSplitter({"train": 0.6, "val": 0.2, "test": 0.2})
         assert sum(splitter.ratios.values()) == 1.0
 
-    def test_ratios_sum_less_than_one(self):
-        """Test that ratios summing to < 1.0 are valid."""
-        splitter = RatioSplitter({"train": 0.7, "test": 0.2})
-        assert abs(sum(splitter.ratios.values()) - 0.9) < 1e-10  # Handle floating point precision
+    def test_ratios_sum_less_than_one_raises_error(self):
+        """Test that ratios summing to < 1.0 are rejected."""
+        with pytest.raises(ValueError, match="must sum to 1.0"):
+            RatioSplitter({"train": 0.7, "test": 0.2})
 
     def test_empty_ratios_raises_error(self):
         """Test that empty ratios dict raises ValueError."""
@@ -31,7 +31,7 @@ class TestRatioSplitterInit:
 
     def test_ratios_exceed_one_raises_error(self):
         """Test that ratios > 1.0 raise ValueError."""
-        with pytest.raises(ValueError, match="exceeds 1.0"):
+        with pytest.raises(ValueError, match="must sum to 1.0"):
             RatioSplitter({"train": 0.8, "test": 0.5})
 
     def test_negative_ratio_raises_error(self):
@@ -46,7 +46,7 @@ class TestRatioSplitterInit:
 
     def test_ratio_exceeds_one_individually_raises_error(self):
         """Test that individual ratio > 1.0 raises ValueError."""
-        with pytest.raises(ValueError, match="exceeds 1.0"):
+        with pytest.raises(ValueError, match="Invalid ratio"):
             RatioSplitter({"train": 1.5})
 
 
@@ -107,6 +107,17 @@ class TestRatioSplitterSplit:
 
         combined_len = sum(len(df) for df in splits.values())
         assert combined_len == len(sample_data)
+
+    def test_split_assigns_rounding_remainder_to_last_split(self):
+        """Test that rounding leftovers are preserved in the final
+        split."""
+        df = pd.DataFrame({"value": range(365)})
+        splitter = RatioSplitter({"train": 0.7, "test": 0.3})
+        splits = splitter.split(df)
+
+        assert len(splits["train"]) == 255
+        assert len(splits["test"]) == 110
+        assert sum(len(part) for part in splits.values()) == 365
 
     def test_split_empty_dataframe_raises_error(self):
         """Test that splitting empty DataFrame raises ValueError."""

--- a/tests/data/processing/features/test_context.py
+++ b/tests/data/processing/features/test_context.py
@@ -52,6 +52,7 @@ def test_with_sector_data_adds_prefixed_columns(base_df, metadata, sector_df):
     step = MarketContextStep(sector_perf_df=sector_df)
     result = step.process(base_df, metadata)
     assert "sector_tech_return" in result.columns
+    assert "sector_tech_return" in metadata.optional_feature_columns
 
 
 def test_with_industry_data_adds_prefixed_columns(base_df, metadata, industry_df):
@@ -104,3 +105,18 @@ def test_non_datetime_index_with_date_column(metadata, sector_df):
     result = step.process(df, metadata)
     # Should still run without error
     assert len(result) == 5
+
+
+def test_sparse_context_uses_latest_known_values(base_df, metadata):
+    sector_df = pd.DataFrame(
+        {
+            "date": [pd.Timestamp("2023-01-02"), pd.Timestamp("2023-01-04")],
+            "tech_return": [0.02, 0.04],
+        }
+    )
+    step = MarketContextStep(sector_perf_df=sector_df)
+    result = step.process(base_df, metadata)
+
+    assert pd.isna(result.loc[pd.Timestamp("2023-01-01"), "sector_tech_return"])
+    assert result.loc[pd.Timestamp("2023-01-03"), "sector_tech_return"] == pytest.approx(0.02)
+    assert result.loc[pd.Timestamp("2023-01-05"), "sector_tech_return"] == pytest.approx(0.04)

--- a/tests/data/processing/steps/alternative/test_analyst.py
+++ b/tests/data/processing/steps/alternative/test_analyst.py
@@ -10,17 +10,9 @@ from quantrl_lab.data.processing.steps.alternative.analyst import AnalystEstimat
 class TestAnalystEstimatesStep:
     """Test AnalystEstimatesStep functionality."""
 
-    def test_monthly_join_alignment(self):
-        """
-        Test that monthly analyst grades are correctly applied to daily
-        data.
-
-        Scenario:
-        - Analyst grade released on 2025-01-01 (Holiday/Weekend).
-        - Trading data starts on 2025-01-03.
-        - Strict join fails (Jan 1 != Jan 3).
-        - Monthly join (Jan == Jan) should succeed.
-        """
+    def test_asof_alignment_carries_latest_grade_forward(self):
+        """Test that analyst grades are aligned using latest-known
+        values."""
         # 1. Create Daily OHLCV Data (Starts Jan 3rd)
         dates = pd.date_range(start="2025-01-03", end="2025-01-10", freq="D")
         ohlcv_df = pd.DataFrame({"Date": dates, "Close": [100.0] * len(dates), "Volume": [1000] * len(dates)})
@@ -37,14 +29,16 @@ class TestAnalystEstimatesStep:
         result = step.process(ohlcv_df, metadata)
 
         # 4. Verify
-        # Jan 3rd should have the grade from Jan 1st (same month)
+        # Jan 3rd should have the grade from Jan 1st (latest known analyst update)
         val_jan3 = result.loc[result["Date"] == "2025-01-03", "analystRatingsStrongBuy"].iloc[0]
 
         assert not np.isnan(val_jan3), "Analyst data should not be NaN for Jan 3rd"
         assert val_jan3 == 10.0
+        assert "analystRatingsStrongBuy" in metadata.optional_feature_columns
 
-    def test_monthly_join_updates_correctly(self):
-        """Test that grades update when the month changes."""
+    def test_asof_alignment_updates_correctly(self):
+        """Test that grades update when a newer analyst release
+        appears."""
         # Data spans Jan and Feb
         dates = pd.date_range(start="2025-01-28", end="2025-02-03", freq="D")
         ohlcv_df = pd.DataFrame({"Date": dates, "Close": [100.0] * len(dates)})
@@ -68,3 +62,42 @@ class TestAnalystEstimatesStep:
         # Feb 1 should have Feb grade (20.0)
         val_feb1 = result.loc[result["Date"] == "2025-02-01", "analystRatingsStrongBuy"].iloc[0]
         assert val_feb1 == 20.0
+
+    def test_rows_before_first_analyst_update_remain_nan(self):
+        """Test dates before the first analyst update are kept with
+        missing optional features."""
+        dates = pd.date_range(start="2025-01-01", end="2025-01-05", freq="D")
+        ohlcv_df = pd.DataFrame({"Date": dates, "Close": [100.0] * len(dates)})
+        grades_df = pd.DataFrame(
+            {"date": [pd.Timestamp("2025-01-03")], "analystRatingsStrongBuy": [10.0], "symbol": ["TEST"]}
+        )
+
+        result = AnalystEstimatesStep(grades_df=grades_df).process(ohlcv_df, ProcessingMetadata())
+
+        assert np.isnan(result.loc[result["Date"] == "2025-01-01", "analystRatingsStrongBuy"].iloc[0])
+        assert result.loc[result["Date"] == "2025-01-04", "analystRatingsStrongBuy"].iloc[0] == 10.0
+
+    def test_panel_data_respects_symbol_boundaries(self):
+        """Test analyst data is aligned per symbol in multi-symbol
+        panels."""
+        ohlcv_df = pd.DataFrame(
+            {
+                "Date": [pd.Timestamp("2025-01-02"), pd.Timestamp("2025-01-02")],
+                "Symbol": ["AAPL", "MSFT"],
+                "Close": [100.0, 200.0],
+            }
+        )
+        grades_df = pd.DataFrame(
+            {
+                "date": [pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-01")],
+                "symbol": ["AAPL", "MSFT"],
+                "analystRatingsStrongBuy": [10.0, 99.0],
+            }
+        )
+
+        result = AnalystEstimatesStep(grades_df=grades_df).process(ohlcv_df, ProcessingMetadata())
+
+        aapl_value = result.loc[result["Symbol"] == "AAPL", "analystRatingsStrongBuy"].iloc[0]
+        msft_value = result.loc[result["Symbol"] == "MSFT", "analystRatingsStrongBuy"].iloc[0]
+        assert aapl_value == 10.0
+        assert msft_value == 99.0

--- a/tests/data/sources/test_async_loaders.py
+++ b/tests/data/sources/test_async_loaders.py
@@ -19,6 +19,8 @@ import pandas as pd
 import pytest
 from aioresponses import aioresponses
 
+from quantrl_lab.data.exceptions import APIConnectionError
+
 # ── YFinanceDataLoader ────────────────────────────────────────────────────────
 
 
@@ -124,14 +126,13 @@ class TestFMPAsyncMethods:
                 assert isinstance(df, pd.DataFrame)
 
     @pytest.mark.asyncio
-    async def test_async_fetch_ohlcv_returns_empty_on_api_failure(self, fmp, base_url):
+    async def test_async_fetch_ohlcv_raises_on_api_failure(self, fmp, base_url):
         with aioresponses() as m:
             for _ in range(4):
                 m.get(re.compile(r".*/historical-price-eod/full.*"), status=500)
             async with aiohttp.ClientSession() as session:
-                sym, df = await fmp.async_fetch_ohlcv(session, "AAPL", start="2023-01-01", end="2023-01-31")
-                assert sym == "AAPL"
-                assert df.empty
+                with pytest.raises(APIConnectionError):
+                    await fmp.async_fetch_ohlcv(session, "AAPL", start="2023-01-01", end="2023-01-31")
 
     @pytest.mark.asyncio
     async def test_async_fetch_ratings_returns_dataframe(self, fmp, base_url):

--- a/tests/data/test_alpha_vantage.py
+++ b/tests/data/test_alpha_vantage.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
+from quantrl_lab.data.exceptions import APIConnectionError, InvalidParametersError, RateLimitError
 from quantrl_lab.data.sources.alpha_vantage_loader import AlphaVantageDataLoader
 
 DAILY_RESPONSE = {
@@ -68,60 +69,59 @@ class TestAlphaVantageDataLoaderInit:
 
 
 class TestGetHistoricalOHLCVData:
-    @patch("quantrl_lab.data.sources.alpha_vantage_loader.requests.get")
-    def test_daily_data_returns_dataframe(self, mock_get):
-        mock_get.return_value = _mock_response(DAILY_RESPONSE)
+    def test_daily_data_returns_dataframe(self):
         loader = AlphaVantageDataLoader(api_key="test_key", rate_limit_delay=0)
-        df = loader.get_historical_ohlcv_data("AAPL", timeframe="1d")
+        with patch.object(loader, "_make_api_request", return_value=DAILY_RESPONSE):
+            df = loader.get_historical_ohlcv_data("AAPL", timeframe="1d")
         assert isinstance(df, pd.DataFrame)
         assert not df.empty
         assert "Close" in df.columns
 
-    @patch("quantrl_lab.data.sources.alpha_vantage_loader.requests.get")
-    def test_empty_response_returns_empty_df(self, mock_get):
-        mock_get.return_value = _mock_response({})
+    def test_empty_response_returns_empty_df(self):
         loader = AlphaVantageDataLoader(api_key="test_key", rate_limit_delay=0)
-        df = loader.get_historical_ohlcv_data("AAPL", timeframe="1d")
+        with patch.object(loader, "_make_api_request", return_value={}):
+            df = loader.get_historical_ohlcv_data("AAPL", timeframe="1d")
         assert isinstance(df, pd.DataFrame)
         assert df.empty
 
-    @patch("quantrl_lab.data.sources.alpha_vantage_loader.requests.get")
-    def test_error_message_in_response_returns_empty(self, mock_get):
-        mock_get.return_value = _mock_response({"Error Message": "Invalid API call"})
+    def test_error_message_in_response_raises(self):
         loader = AlphaVantageDataLoader(api_key="bad_key", rate_limit_delay=0)
-        df = loader.get_historical_ohlcv_data("AAPL", timeframe="1d")
-        assert df.empty
+        with patch.object(loader._request_wrapper, "make_request", return_value={"Error Message": "Invalid API call"}):
+            with pytest.raises(InvalidParametersError):
+                loader.get_historical_ohlcv_data("AAPL", timeframe="1d")
 
     def test_invalid_timeframe_raises(self):
         loader = AlphaVantageDataLoader(api_key="key")
         with pytest.raises(Exception):
             loader.get_historical_ohlcv_data("AAPL", timeframe="2w")
 
-    @patch("quantrl_lab.data.sources.alpha_vantage_loader.requests.get")
-    def test_date_filtering_applied(self, mock_get):
-        mock_get.return_value = _mock_response(DAILY_RESPONSE)
+    def test_date_filtering_applied(self):
         loader = AlphaVantageDataLoader(api_key="test_key", rate_limit_delay=0)
-        df = loader.get_historical_ohlcv_data("AAPL", start="2023-01-04", end="2023-12-31", timeframe="1d")
+        with patch.object(loader, "_make_api_request", return_value=DAILY_RESPONSE):
+            df = loader.get_historical_ohlcv_data("AAPL", start="2023-01-04", end="2023-12-31", timeframe="1d")
         assert isinstance(df, pd.DataFrame)
         # Only the 2023-01-04 row should remain
         assert len(df) == 1
 
 
 class TestMakeApiRequest:
-    @patch("quantrl_lab.data.sources.alpha_vantage_loader.requests.get")
-    def test_returns_none_on_failure(self, mock_get):
-        import requests as req
-
-        mock_get.side_effect = req.exceptions.ConnectionError("Network error")
+    def test_raises_connection_error_on_failure(self):
         loader = AlphaVantageDataLoader(api_key="key", max_retries=1, delay=0, rate_limit_delay=0)
-        result = loader._make_api_request("TIME_SERIES_DAILY", symbol="AAPL")
-        assert result is None
+        with patch.object(
+            loader._request_wrapper,
+            "make_request",
+            side_effect=APIConnectionError("Network error"),
+        ):
+            with pytest.raises(APIConnectionError):
+                loader._make_api_request("TIME_SERIES_DAILY", symbol="AAPL")
 
-    @patch("quantrl_lab.data.sources.alpha_vantage_loader.requests.get")
-    def test_rate_limit_note_triggers_retry(self, mock_get):
-        """API Note about rate limit should retry and eventually return
-        None."""
-        mock_get.return_value = _mock_response({"Note": "Thank you for using Alpha Vantage! API call frequency"})
+    def test_rate_limit_note_raises(self):
+        """API Note about rate limit should raise a typed exception."""
         loader = AlphaVantageDataLoader(api_key="key", max_retries=2, delay=0, rate_limit_delay=0)
-        result = loader._make_api_request("TIME_SERIES_DAILY", symbol="AAPL")
-        assert result is None
+        with patch.object(
+            loader._request_wrapper,
+            "make_request",
+            return_value={"Note": "Thank you for using Alpha Vantage! API call frequency"},
+        ):
+            with pytest.raises(RateLimitError):
+                loader._make_api_request("TIME_SERIES_DAILY", symbol="AAPL")

--- a/tests/data/test_data_sources.py
+++ b/tests/data/test_data_sources.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
-from quantrl_lab.data.exceptions import AuthenticationError, InvalidParametersError
+from quantrl_lab.data.exceptions import AuthenticationError, DataSourceError, InvalidParametersError, RateLimitError
 from quantrl_lab.data.interface import (
     FundamentalDataCapable,
     HistoricalDataCapable,
@@ -104,11 +104,10 @@ class TestYFinanceDataLoader:
                 end="2023-01-01",
             )
 
-    @patch("quantrl_lab.data.sources.yfinance_loader.yf.Ticker")
-    def test_get_historical_ohlcv_data_returns_dataframe(self, mock_ticker):
+    @patch("quantrl_lab.data.sources.yfinance_loader.yf.download")
+    def test_get_historical_ohlcv_data_returns_dataframe(self, mock_download):
         """Test that get_historical_ohlcv_data returns a DataFrame."""
-        # Setup mock
-        mock_history = pd.DataFrame(
+        mock_download.return_value = pd.DataFrame(
             {
                 "Open": [150.0, 151.0],
                 "High": [152.0, 153.0],
@@ -119,10 +118,6 @@ class TestYFinanceDataLoader:
             index=pd.date_range("2023-01-01", periods=2),
         )
 
-        mock_ticker_instance = MagicMock()
-        mock_ticker_instance.history.return_value = mock_history
-        mock_ticker.return_value = mock_ticker_instance
-
         loader = YFinanceDataLoader()
         result = loader.get_historical_ohlcv_data(
             symbols="AAPL",
@@ -132,6 +127,33 @@ class TestYFinanceDataLoader:
 
         assert isinstance(result, pd.DataFrame)
         assert "Symbol" in result.columns
+
+    @patch("quantrl_lab.data.sources.yfinance_loader.yf.download")
+    def test_get_historical_ohlcv_data_normalizes_multi_symbol_download(self, mock_download):
+        """Test multi-symbol download normalization preserves every
+        requested symbol."""
+        columns = pd.MultiIndex.from_product(
+            [["Open", "High", "Low", "Close", "Volume"], ["AAPL", "MSFT"]],
+        )
+        mock_download.return_value = pd.DataFrame(
+            [
+                [150.0, 300.0, 152.0, 302.0, 149.0, 299.0, 151.0, 301.0, 1000000, 2000000],
+                [151.0, 301.0, 153.0, 303.0, 150.0, 300.0, 152.0, 302.0, 1100000, 2100000],
+            ],
+            index=pd.date_range("2023-01-01", periods=2),
+            columns=columns,
+        )
+
+        loader = YFinanceDataLoader()
+        result = loader.get_historical_ohlcv_data(
+            symbols=["AAPL", "MSFT"],
+            start="2023-01-01",
+            end="2023-01-31",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert set(result["Symbol"]) == {"AAPL", "MSFT"}
+        assert len(result) == 4
 
     @patch("quantrl_lab.data.sources.yfinance_loader.yf.Ticker")
     def test_get_fundamental_data_returns_dataframe(self, mock_ticker):
@@ -256,15 +278,11 @@ class TestAlpacaDataLoader:
     @patch.dict("os.environ", {"ALPACA_API_KEY": "test_key", "ALPACA_SECRET_KEY": "test_secret"})
     @patch("quantrl_lab.data.sources.alpaca_loader.StockHistoricalDataClient")
     @patch("quantrl_lab.data.sources.alpaca_loader.StockDataStream")
-    @patch("quantrl_lab.data.sources.alpaca_loader.requests.get")
-    def test_get_news_data_returns_dataframe(self, mock_requests, mock_stream, mock_client):
+    def test_get_news_data_returns_dataframe(self, mock_stream, mock_client):
         """Test that get_news_data returns a DataFrame."""
         AlpacaDataLoader._stock_stream_client_instance = None
 
-        # Setup mock response
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
+        mock_payload = {
             "news": [
                 {
                     "headline": "Test headline",
@@ -274,53 +292,43 @@ class TestAlpacaDataLoader:
             ],
             "next_page_token": None,
         }
-        mock_requests.return_value = mock_response
 
         loader = AlpacaDataLoader()
-        result = loader.get_news_data(
-            symbols="AAPL",
-            start="2023-01-01",
-            end="2023-01-31",
-        )
+        with patch.object(loader._news_request_wrapper, "make_request", return_value=mock_payload):
+            result = loader.get_news_data(
+                symbols="AAPL",
+                start="2023-01-01",
+                end="2023-01-31",
+            )
 
         assert isinstance(result, pd.DataFrame)
         assert len(result) == 1
         assert result.iloc[0]["headline"] == "Test headline"
 
     @patch.dict("os.environ", {"ALPACA_API_KEY": "test_key", "ALPACA_SECRET_KEY": "test_secret"})
-    @patch("quantrl_lab.data.sources.alpaca_loader.requests.get")
-    def test_get_news_data_silent_errors(self, mock_requests):
+    def test_get_news_data_silent_errors(self):
         """Test that silent_errors=True suppresses exceptions."""
-        import requests
-
-        # Simulate connection error
-        mock_requests.side_effect = requests.exceptions.RequestException("Connection failed")
-
         loader = AlpacaDataLoader()
 
-        # Should not raise exception, returns empty DataFrame
-        result = loader.get_news_data(symbols="AAPL", start="2023-01-01", silent_errors=True)
+        with patch.object(
+            loader._news_request_wrapper, "make_request", side_effect=DataSourceError("Connection failed")
+        ):
+            result = loader.get_news_data(symbols="AAPL", start="2023-01-01", silent_errors=True)
 
         assert isinstance(result, pd.DataFrame)
         assert result.empty
 
     @patch.dict("os.environ", {"ALPACA_API_KEY": "test_key", "ALPACA_SECRET_KEY": "test_secret"})
-    @patch("quantrl_lab.data.sources.alpaca_loader.requests.get")
-    def test_get_news_data_raises_without_silent_errors(self, mock_requests):
-        """Test that silent_errors=False (default) logs error but
-        doesn't crash loop, returns empty if all fail."""
-        import requests
-
-        mock_requests.side_effect = requests.exceptions.RequestException("Connection failed")
-
+    def test_get_news_data_raises_without_silent_errors(self):
+        """Test that silent_errors=False propagates provider
+        failures."""
         loader = AlpacaDataLoader()
 
-        # The current implementation catches Exception and logs ERROR, then breaks.
-        # It returns an empty DataFrame if no news collected.
-        result = loader.get_news_data(symbols="AAPL", start="2023-01-01", silent_errors=False)
-
-        assert isinstance(result, pd.DataFrame)
-        assert result.empty
+        with patch.object(
+            loader._news_request_wrapper, "make_request", side_effect=DataSourceError("Connection failed")
+        ):
+            with pytest.raises(DataSourceError, match="Connection failed"):
+                loader.get_news_data(symbols="AAPL", start="2023-01-01", silent_errors=False)
 
 
 class TestAlphaVantageDataLoader:
@@ -373,13 +381,9 @@ class TestAlphaVantageDataLoader:
             )
 
     @patch.dict("os.environ", {"ALPHA_VANTAGE_API_KEY": "test_key"})
-    @patch("quantrl_lab.data.sources.alpha_vantage_loader.requests.get")
-    def test_get_historical_ohlcv_data_daily(self, mock_requests):
+    def test_get_historical_ohlcv_data_daily(self):
         """Test get_historical_ohlcv_data with daily timeframe."""
-        # Setup mock response
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
+        mock_response = {
             "Time Series (Daily)": {
                 "2023-01-15": {
                     "1. open": "150.0",
@@ -390,26 +394,22 @@ class TestAlphaVantageDataLoader:
                 },
             },
         }
-        mock_requests.return_value = mock_response
 
         loader = AlphaVantageDataLoader()
-        result = loader.get_historical_ohlcv_data(
-            symbols="AAPL",
-            start="2023-01-01",
-            end="2023-01-31",
-            timeframe="1d",
-        )
+        with patch.object(loader, "_make_api_request", return_value=mock_response):
+            result = loader.get_historical_ohlcv_data(
+                symbols="AAPL",
+                start="2023-01-01",
+                end="2023-01-31",
+                timeframe="1d",
+            )
 
         assert isinstance(result, pd.DataFrame)
 
     @patch.dict("os.environ", {"ALPHA_VANTAGE_API_KEY": "test_key"})
-    @patch("quantrl_lab.data.sources.alpha_vantage_loader.requests.get")
-    def test_get_historical_ohlcv_data_intraday(self, mock_requests):
+    def test_get_historical_ohlcv_data_intraday(self):
         """Test get_historical_ohlcv_data with intraday timeframe."""
-        # Setup mock response
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
+        mock_response = {
             "Time Series (5min)": {
                 "2023-01-15 10:00:00": {
                     "1. open": "150.0",
@@ -420,15 +420,15 @@ class TestAlphaVantageDataLoader:
                 },
             },
         }
-        mock_requests.return_value = mock_response
 
         loader = AlphaVantageDataLoader()
-        result = loader.get_historical_ohlcv_data(
-            symbols="AAPL",
-            start="2023-01-01",
-            end="2023-01-31",
-            timeframe="5min",
-        )
+        with patch.object(loader, "_make_api_request", return_value=mock_response):
+            result = loader.get_historical_ohlcv_data(
+                symbols="AAPL",
+                start="2023-01-01",
+                end="2023-01-31",
+                timeframe="5min",
+            )
 
         assert isinstance(result, pd.DataFrame)
 
@@ -476,43 +476,53 @@ class TestAlphaVantageDataLoader:
             loader._get_federal_funds_rate_data(interval="invalid")
 
     @patch.dict("os.environ", {"ALPHA_VANTAGE_API_KEY": "test_key"})
-    @patch("quantrl_lab.data.sources.alpha_vantage_loader.requests.get")
-    def test_make_api_request_handles_rate_limit(self, mock_requests):
-        """Test that _make_api_request handles rate limit responses."""
-        # First call returns rate limit note, second succeeds
-        rate_limit_response = MagicMock()
-        rate_limit_response.status_code = 200
-        rate_limit_response.json.return_value = {
-            "Note": "API call frequency is 5 calls per minute",
-        }
-
-        success_response = MagicMock()
-        success_response.status_code = 200
-        success_response.json.return_value = {"data": "test"}
-
-        mock_requests.side_effect = [rate_limit_response, success_response]
-
-        loader = AlphaVantageDataLoader(delay=0)  # Set delay to 0 for faster tests
-        result = loader._make_api_request("TEST_FUNCTION", "AAPL")
-
-        assert result == {"data": "test"}
+    def test_make_api_request_handles_rate_limit(self):
+        """Test that _make_api_request raises typed rate limit
+        errors."""
+        loader = AlphaVantageDataLoader(delay=0)
+        with patch.object(
+            loader._request_wrapper,
+            "make_request",
+            return_value={"Note": "API call frequency is 5 calls per minute"},
+        ):
+            with pytest.raises(RateLimitError):
+                loader._make_api_request("TEST_FUNCTION", "AAPL")
 
     @patch.dict("os.environ", {"ALPHA_VANTAGE_API_KEY": "test_key"})
-    @patch("quantrl_lab.data.sources.alpha_vantage_loader.requests.get")
-    def test_make_api_request_handles_error_message(self, mock_requests):
-        """Test that _make_api_request handles error message
-        responses."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "Error Message": "Invalid API call",
-        }
-        mock_requests.return_value = mock_response
-
+    def test_make_api_request_handles_error_message(self):
+        """Test that _make_api_request raises invalid parameter
+        errors."""
         loader = AlphaVantageDataLoader()
-        result = loader._make_api_request("TEST_FUNCTION", "INVALID")
+        with patch.object(loader._request_wrapper, "make_request", return_value={"Error Message": "Invalid API call"}):
+            with pytest.raises(InvalidParametersError, match="Invalid API call"):
+                loader._make_api_request("TEST_FUNCTION", "INVALID")
 
-        assert result is None
+    @patch.dict("os.environ", {"ALPHA_VANTAGE_API_KEY": "test_key"})
+    def test_get_news_data_expands_multi_symbol_sentiment(self):
+        """Test news normalization emits one row per matched article-
+        symbol pair."""
+        loader = AlphaVantageDataLoader()
+        with patch.object(
+            loader,
+            "_make_api_request",
+            return_value={
+                "feed": [
+                    {
+                        "title": "Chip demand improves",
+                        "time_published": "20230115T100000",
+                        "ticker_sentiment": [
+                            {"ticker": "AAPL", "ticker_sentiment_score": "0.30"},
+                            {"ticker": "MSFT", "ticker_sentiment_score": "0.70"},
+                        ],
+                    }
+                ]
+            },
+        ):
+            result = loader.get_news_data(["AAPL", "MSFT"], start="2023-01-01", end="2023-01-31")
+
+        assert len(result) == 2
+        assert set(result["Symbol"]) == {"AAPL", "MSFT"}
+        assert set(result["sentiment_score"]) == {0.3, 0.7}
 
 
 class TestDataSourceRegistry:
@@ -530,6 +540,8 @@ class TestDataSourceRegistry:
 
         assert hasattr(registry, "primary_source")
         assert hasattr(registry, "news_source")
+        assert "primary_source" in registry.list_sources_by_capability("historical_bars")
+        assert "news_source" in registry.list_sources_by_capability("news")
 
     @patch.dict("os.environ", {"ALPACA_API_KEY": "test_key", "ALPACA_SECRET_KEY": "test_secret"})
     @patch("quantrl_lab.data.sources.alpaca_loader.StockHistoricalDataClient")
@@ -568,6 +580,17 @@ class TestDataSourceRegistry:
         )
 
         assert isinstance(result, pd.DataFrame)
+
+    def test_register_source_infers_capabilities_from_factory_instance(self):
+        """Test custom zero-arg factories remain discoverable by
+        capability."""
+        from quantrl_lab.data.source_registry import DataSourceRegistry
+
+        registry = DataSourceRegistry(sources={})
+        registry.register_source("custom", lambda: YFinanceDataLoader())
+
+        assert "custom" in registry.list_sources_by_capability("historical_bars")
+        assert "custom" in registry.list_sources_by_capability("fundamental_data")
 
 
 class TestFMPDataSource:

--- a/tests/data/test_data_sources_integration.py
+++ b/tests/data/test_data_sources_integration.py
@@ -19,6 +19,8 @@ import pandas as pd
 import pytest
 from dotenv import load_dotenv
 
+from quantrl_lab.data.exceptions import AuthenticationError, RateLimitError
+
 # Load environment variables from .env file
 load_dotenv()
 
@@ -277,7 +279,10 @@ class TestAlphaVantageIntegration:
         from quantrl_lab.data.sources.alpha_vantage_loader import AlphaVantageDataLoader
 
         loader = AlphaVantageDataLoader()
-        result = loader._get_company_overview("IBM")
+        try:
+            result = loader._get_company_overview("IBM")
+        except (AuthenticationError, RateLimitError):
+            pytest.skip("Alpha Vantage provider throttled or rejected the request")
 
         # May be None or rate limited
         if result is not None and not self._is_rate_limited(result):
@@ -289,7 +294,10 @@ class TestAlphaVantageIntegration:
         from quantrl_lab.data.sources.alpha_vantage_loader import AlphaVantageDataLoader
 
         loader = AlphaVantageDataLoader()
-        result = loader._get_real_gdp_data(interval="annual")
+        try:
+            result = loader._get_real_gdp_data(interval="annual")
+        except (AuthenticationError, RateLimitError):
+            pytest.skip("Alpha Vantage provider throttled or rejected the request")
 
         # May be None or rate limited
         if result is not None and not self._is_rate_limited(result):

--- a/tests/data/test_processor_integration.py
+++ b/tests/data/test_processor_integration.py
@@ -39,7 +39,7 @@ class TestDataProcessorSplitting:
 
         # Check sizes
         assert len(result["train"]) == 255  # 70% of 365
-        assert len(result["test"]) == 109  # 30% of 365
+        assert len(result["test"]) == 110  # Remainder is kept in the last split
 
         # Check metadata
         assert metadata["date_ranges"]["train"]["start"] == "2020-01-01"
@@ -85,7 +85,7 @@ class TestDataProcessorSplitting:
 
         # Verify total equals original (after dropna)
         total_len = sum(len(df) for df in result.values())
-        assert total_len <= len(sample_ohlcv_data)  # May be less due to dropna
+        assert total_len == len(sample_ohlcv_data)
 
     def test_no_split_returns_single_dataframe(self, sample_ohlcv_data):
         """Test that not providing split_config returns single
@@ -215,10 +215,9 @@ class TestDataProcessorDirectSplitterUsage:
 class TestDataProcessorCleanup:
     """Test data cleanup and dropna logic."""
 
-    def test_dropna_removes_any_nan(self):
-        """Test that rows with ANY NaN values (like indicator warm-up)
-        are dropped."""
-        # Create data where a feature has NaNs at the start
+    def test_indicator_warmup_rows_are_dropped(self):
+        """Test that generated technical indicators still trim warm-up
+        rows."""
         dates = pd.date_range("2020-01-01", periods=10, freq="D")
         df = pd.DataFrame(
             {
@@ -228,17 +227,41 @@ class TestDataProcessorCleanup:
                 "Low": [100] * 10,
                 "Close": [100] * 10,
                 "Volume": [100] * 10,
-                # Feature with 3 leading NaNs
-                "SMA_3": [None, None, None] + [100.0] * 7,
             }
         )
 
         processor = DataProcessor(df)
-        # Run pipeline (no new indicators, just cleanup)
-        result, _ = processor.data_processing_pipeline()
+        result, _ = processor.data_processing_pipeline(indicators=[{"SMA": {"window": 3}}])
 
-        # Should drop first 3 rows
-        assert len(result) == 7
-        # Check first row is the 4th original row (index 3, Open=3)
-        # We can't check Date as it's dropped by default cleanup
-        assert result.iloc[0]["Open"] == 3
+        assert len(result) == 8
+        assert result.iloc[0]["Open"] == 2
+
+    def test_optional_sparse_enrichment_does_not_drop_rows(self):
+        """Test sparse optional enrichment no longer deletes valid OHLCV
+        rows."""
+        dates = pd.date_range("2020-01-01", periods=10, freq="D")
+        df = pd.DataFrame(
+            {
+                "Date": dates,
+                "Open": range(10),
+                "High": [100] * 10,
+                "Low": [100] * 10,
+                "Close": [100] * 10,
+                "Volume": [100] * 10,
+            }
+        )
+        analyst_grades = pd.DataFrame(
+            {
+                "date": [pd.Timestamp("2020-01-05")],
+                "analystRatingsStrongBuy": [7.0],
+                "symbol": ["AAPL"],
+            }
+        )
+
+        processor = DataProcessor(df, analyst_grades=analyst_grades)
+        result, metadata = processor.data_processing_pipeline()
+
+        assert len(result) == 10
+        assert "analystRatingsStrongBuy" in result.columns
+        assert result.loc[result["Open"] == 0, "analystRatingsStrongBuy"].isna().all()
+        assert "analystRatingsStrongBuy" in metadata["optional_feature_columns"]

--- a/tests/data/test_protocols.py
+++ b/tests/data/test_protocols.py
@@ -87,6 +87,8 @@ class TestYfinanceProtocols:
 
         assert "historical_bars" in features
         assert "fundamental_data" in features
+        assert "connection_managed" not in features
+        assert "instrument_discovery" not in features
         assert "live_data" not in features
         assert "news" not in features
         assert "streaming" not in features
@@ -302,6 +304,8 @@ class TestAlphaVantageProtocols:
         assert "fundamental_data" in features
         assert "macro_data" in features
         assert "news" in features
+        assert "connection_managed" not in features
+        assert "instrument_discovery" not in features
         assert "live_data" not in features
         assert "streaming" not in features
         assert "analyst_data" not in features
@@ -383,6 +387,8 @@ class TestFMPProtocols:
         assert "analyst_data" in features
         assert "sector_data" in features
         assert "company_profile" in features
+        assert "connection_managed" not in features
+        assert "instrument_discovery" not in features
         assert "live_data" not in features
         assert "news" not in features
         assert "streaming" not in features

--- a/tests/data/utils/test_async_request_utils.py
+++ b/tests/data/utils/test_async_request_utils.py
@@ -6,6 +6,7 @@ import re
 import pytest
 from aioresponses import aioresponses
 
+from quantrl_lab.data.exceptions import APIConnectionError, RateLimitError
 from quantrl_lab.data.utils.async_request_utils import AsyncHTTPRequestWrapper
 
 
@@ -90,7 +91,7 @@ class TestAsyncHTTPRequestWrapperMakeRequest:
         assert result == {"symbol": "AAPL", "price": 150.0}
 
     @pytest.mark.asyncio
-    async def test_returns_none_after_all_retries_exhausted(self):
+    async def test_raises_connection_error_after_all_retries_exhausted(self):
         wrapper = AsyncHTTPRequestWrapper(max_retries=2, base_delay=0.01)
         url = "https://api.example.com/data"
 
@@ -101,9 +102,8 @@ class TestAsyncHTTPRequestWrapperMakeRequest:
             import aiohttp
 
             async with aiohttp.ClientSession() as session:
-                result = await wrapper.make_request(session, url)
-
-        assert result is None
+                with pytest.raises(APIConnectionError):
+                    await wrapper.make_request(session, url)
 
     @pytest.mark.asyncio
     async def test_retries_on_server_error_then_succeeds(self):
@@ -134,6 +134,20 @@ class TestAsyncHTTPRequestWrapperMakeRequest:
                 result = await wrapper.make_request(session, url)
 
         assert result == {"data": "ok"}
+
+    @pytest.mark.asyncio
+    async def test_raises_rate_limit_error_when_exhausted(self):
+        wrapper = AsyncHTTPRequestWrapper(max_retries=1, base_delay=0.01)
+        url = "https://api.example.com/data"
+
+        with aioresponses() as m:
+            m.get(url, status=429, payload={"message": "rate limit"})
+            m.get(url, status=429, payload={"message": "rate limit"})
+            import aiohttp
+
+            async with aiohttp.ClientSession() as session:
+                with pytest.raises(RateLimitError):
+                    await wrapper.make_request(session, url)
 
     @pytest.mark.asyncio
     async def test_passes_params_in_request(self):

--- a/tests/data/utils/test_request_utils.py
+++ b/tests/data/utils/test_request_utils.py
@@ -4,8 +4,8 @@ import time
 from unittest.mock import MagicMock, patch
 
 import pytest
-import requests
 
+from quantrl_lab.data.exceptions import APIConnectionError, AuthenticationError, RateLimitError
 from quantrl_lab.data.utils.request_utils import (
     HTTPRequestWrapper,
     RetryStrategy,
@@ -50,14 +50,14 @@ class TestHTTPRequestWrapper:
             # First call fails, second succeeds
             mock_fail = MagicMock()
             mock_fail.status_code = 500
-            # Need to set response attribute for error detection
-            mock_fail.response = mock_fail
-            http_error = requests.HTTPError()
-            http_error.response = mock_fail
-            mock_fail.raise_for_status.side_effect = http_error
+            mock_fail.url = "https://api.example.com/data"
+            mock_fail.headers = {}
+            mock_fail.json.return_value = {"error": "server error"}
 
             mock_success = MagicMock()
             mock_success.status_code = 200
+            mock_success.url = "https://api.example.com/data"
+            mock_success.headers = {}
             mock_success.json.return_value = {"data": "success"}
 
             mock_request.side_effect = [mock_fail, mock_success]
@@ -74,13 +74,12 @@ class TestHTTPRequestWrapper:
         with patch("requests.request") as mock_request:
             mock_response = MagicMock()
             mock_response.status_code = 500
-            mock_response.response = mock_response
-            http_error = requests.HTTPError()
-            http_error.response = mock_response
-            mock_response.raise_for_status.side_effect = http_error
+            mock_response.url = "https://api.example.com/data"
+            mock_response.headers = {}
+            mock_response.json.return_value = {"error": "server error"}
             mock_request.return_value = mock_response
 
-            with pytest.raises(requests.HTTPError):
+            with pytest.raises(APIConnectionError):
                 wrapper.make_request("https://api.example.com/data", raise_on_error=True)
 
             # Should be called max_retries + 1 times (initial + retries)
@@ -176,6 +175,8 @@ class TestHTTPRequestWrapper:
         with patch("requests.request") as mock_request:
             mock_response = MagicMock()
             mock_response.status_code = 200
+            mock_response.url = "https://api.example.com/data"
+            mock_response.headers = {}
             mock_response.json.return_value = {"success": True}
             mock_request.return_value = mock_response
 
@@ -194,6 +195,8 @@ class TestHTTPRequestWrapper:
         with patch("requests.request") as mock_request:
             mock_response = MagicMock()
             mock_response.status_code = 200
+            mock_response.url = "https://api.example.com/data"
+            mock_response.headers = {}
             mock_response.json.return_value = {"data": "test"}
             mock_request.return_value = mock_response
 
@@ -210,6 +213,8 @@ class TestHTTPRequestWrapper:
         with patch("requests.request") as mock_request:
             mock_response = MagicMock()
             mock_response.status_code = 200
+            mock_response.url = "https://api.example.com/data"
+            mock_response.headers = {}
             mock_response.json.return_value = {"data": "test"}
             mock_request.return_value = mock_response
 
@@ -226,6 +231,8 @@ class TestHTTPRequestWrapper:
         with patch("requests.request") as mock_request:
             mock_response = MagicMock()
             mock_response.status_code = 200
+            mock_response.url = "https://api.example.com/data"
+            mock_response.headers = {}
             mock_response.json.return_value = {"data": "test"}
             mock_request.return_value = mock_response
 
@@ -244,6 +251,8 @@ class TestHTTPRequestWrapper:
         with patch("requests.request") as mock_request:
             mock_response = MagicMock()
             mock_response.status_code = 200
+            mock_response.url = "https://api.example.com/data"
+            mock_response.headers = {}
             mock_response.json.return_value = {"status": "error", "message": "test"}
             mock_request.return_value = mock_response
 
@@ -257,6 +266,8 @@ class TestHTTPRequestWrapper:
         with patch("requests.request") as mock_request:
             mock_response = MagicMock()
             mock_response.status_code = 200
+            mock_response.url = "https://api.example.com/data"
+            mock_response.headers = {}
             mock_response.json.side_effect = ValueError("Not JSON")
             mock_response.text = "Plain text response"
             mock_request.return_value = mock_response
@@ -273,10 +284,9 @@ class TestHTTPRequestWrapper:
         with patch("requests.request") as mock_request:
             mock_response = MagicMock()
             mock_response.status_code = 500
-            mock_response.response = mock_response
-            http_error = requests.HTTPError()
-            http_error.response = mock_response
-            mock_response.raise_for_status.side_effect = http_error
+            mock_response.url = "https://api.example.com/data"
+            mock_response.headers = {}
+            mock_response.json.return_value = {"error": "server error"}
             mock_request.return_value = mock_response
 
             result = wrapper.make_request("https://api.example.com/data", raise_on_error=False)
@@ -291,14 +301,15 @@ class TestHTTPRequestWrapper:
             # First request gets rate limited
             mock_rate_limit = MagicMock()
             mock_rate_limit.status_code = 429
-            http_error = requests.HTTPError()
-            http_error.response = mock_rate_limit
-            mock_rate_limit.raise_for_status.side_effect = http_error
-            mock_rate_limit.response = mock_rate_limit
+            mock_rate_limit.url = "https://api.example.com/data"
+            mock_rate_limit.headers = {}
+            mock_rate_limit.json.return_value = {"error": "rate limit exceeded"}
 
             # Second request succeeds
             mock_success = MagicMock()
             mock_success.status_code = 200
+            mock_success.url = "https://api.example.com/data"
+            mock_success.headers = {}
             mock_success.json.return_value = {"data": "test"}
 
             mock_request.side_effect = [mock_rate_limit, mock_success]
@@ -311,6 +322,41 @@ class TestHTTPRequestWrapper:
             assert result == {"data": "test"}
             # Should have delayed by base_delay * multiplier = 0.05 * 2 = 0.1
             assert elapsed >= 0.1
+
+    def test_authentication_error_does_not_retry(self):
+        """Test that auth failures raise immediately."""
+        wrapper = HTTPRequestWrapper(max_retries=3, base_delay=0.01)
+
+        with patch("requests.request") as mock_request:
+            mock_response = MagicMock()
+            mock_response.status_code = 401
+            mock_response.url = "https://api.example.com/data"
+            mock_response.headers = {}
+            mock_response.json.return_value = {"error": "unauthorized"}
+            mock_request.return_value = mock_response
+
+            with pytest.raises(AuthenticationError):
+                wrapper.make_request("https://api.example.com/data")
+
+            mock_request.assert_called_once()
+
+    def test_rate_limit_error_exposes_retry_after(self):
+        """Test Retry-After header propagation on rate limit
+        failures."""
+        wrapper = HTTPRequestWrapper(max_retries=0)
+
+        with patch("requests.request") as mock_request:
+            mock_response = MagicMock()
+            mock_response.status_code = 429
+            mock_response.url = "https://api.example.com/data"
+            mock_response.headers = {"Retry-After": "7"}
+            mock_response.json.return_value = {"error": "rate limit exceeded"}
+            mock_request.return_value = mock_response
+
+            with pytest.raises(RateLimitError) as exc_info:
+                wrapper.make_request("https://api.example.com/data")
+
+            assert exc_info.value.retry_after == 7
 
 
 class TestCreateDefaultWrapper:


### PR DESCRIPTION
## Summary

  This PR tightens the `quantrl_lab.data` contract surface and fixes several correctness issues in the loading and processing
  pipeline.

  The main focus is making data-source capabilities explicit, standardizing loader error behavior, preserving valid rows when
  optional enrichment data is sparse, and fixing a few data-quality and scalability issues in the source loaders and
  splitters.

  ## What changed

  - made data-source capability reporting explicit via `SUPPORTED_FEATURES`
  - updated `DataSourceRegistry` to use capability metadata instead of unreliable runtime inference
  - standardized request wrappers and loader error handling around typed `DataSourceError` subclasses
  - fixed Alpha Vantage multi-symbol news sentiment extraction
  - improved YFinance multi-symbol historical fetch behavior
  - fixed ratio splitting so all rows are preserved and ratios must sum to `1.0`
  - replaced global `dropna()` cleanup with required-vs-optional feature handling
  - added backward as-of alignment for sparse analyst and market-context enrichment
  - fixed symbol-aware analyst alignment for panel data
  - hardened `examples/data_sources` so they fail gracefully on missing credentials, premium-only endpoints, and provider
  throttling

  ## Why

  Before this change, the data module had a few weak spots:

  - capability reporting produced false positives
  - sparse enrichment data could delete otherwise valid OHLCV rows
  - some provider failures were silently converted into empty data
  - Alpha Vantage multi-symbol sentiment handling was incorrect
  - YFinance multi-symbol fetches did not scale well
  - ratio-based splitting could drop rows

  This PR makes the behavior more explicit and predictable for downstream users.

  ## Validation

  - `uv run pytest tests/data -q`
  - `pre-commit run --files <touched files>`
  - ran the updated data source examples under `examples/data_sources`

  ## Notes

  - capability reporting is now corrected and may differ from previous false-positive results
  - some loader paths now raise typed source errors where they previously returned empty frames
  - example scripts were updated to behave as smoke tests rather than crash on provider limitations