### PR TITLE
feat(data): refactor processing pipeline and decouple alpha research integration

### DIFF
--- a/docs/data-processing.md
+++ b/docs/data-processing.md
@@ -19,13 +19,40 @@ Both produce the same output: a cleaned, feature-enriched DataFrame (and optiona
 | `SentimentEnrichmentStep` | Merges news sentiment scores | `news_data`, `provider`, `fillna_strategy` |
 | `AnalystEstimatesStep` | Merges analyst grades / ratings | `grades_df`, `ratings_df` |
 | `MarketContextStep` | Merges sector / industry performance | `sector_perf_df`, `industry_perf_df` |
-| `CrossSectionalStep` | Computes cross-sectional features across a basket | `columns`, `methods` |
+| `CrossSectionalStep` | Computes cross-sectional features across a basket | `columns`, `methods`, `date_column` |
 
 ---
 
 ## High-Level Usage: `DataProcessor`
 
 Use `DataProcessor` when you want a single call to handle everything — indicators, sentiment, analyst data, numeric conversion, cleanup, and optional splitting.
+
+### Typed config assembly
+
+`DataProcessor` now supports typed pipeline config objects when you want a clearer, more inspectable assembly flow:
+
+```python
+from quantrl_lab.data.processing import (
+    CleanupConfig,
+    CrossSectionalConfig,
+    ProcessingPipelineConfig,
+    SplitConfig,
+)
+
+pipeline_config = ProcessingPipelineConfig(
+    indicators=[{"SMA": {"window": 20}}, "RSI"],
+    cross_sectional=CrossSectionalConfig(columns=["Close"], methods=["rank"]),
+    split=SplitConfig(splits={"train": 0.7, "test": 0.3}),
+    cleanup=CleanupConfig(),
+    strict_indicators=True,
+)
+
+pipeline = processor.build_pipeline(pipeline_config=pipeline_config)
+print(pipeline.get_step_names())
+print(pipeline.describe())
+
+processed, metadata = processor.data_processing_pipeline(pipeline_config=pipeline_config)
+```
 
 ### Minimal example
 
@@ -229,6 +256,18 @@ print(pipeline)
 print(len(pipeline))   # 2
 ```
 
+`DataPipeline.describe()` returns a structured summary:
+
+```python
+{
+    "step_count": 2,
+    "steps": [
+        {"index": 1, "name": "Technical Indicators", "type": "TechnicalIndicatorStep"},
+        {"index": 2, "name": "Column Cleanup", "type": "ColumnCleanupStep"},
+    ],
+}
+```
+
 ---
 
 ## Step Reference
@@ -368,6 +407,11 @@ Added columns are prefixed with `sector_` and `industry_` respectively. Pass onl
 ### `CrossSectionalStep`
 
 Computes cross-sectional features across a **basket of stocks** (panel data). Groups by date and normalises each feature relative to all stocks present on that day. Only meaningful with 2+ symbols; silently bypasses if a single symbol is detected.
+
+The step now works with either:
+- a `DatetimeIndex`
+- a date-like column such as `Date` / `Timestamp`
+- an explicit `date_column=...` override
 
 ```python
 from quantrl_lab.data.processing.steps import CrossSectionalStep

--- a/examples/alpha_research/multi_symbol_selection.py
+++ b/examples/alpha_research/multi_symbol_selection.py
@@ -1,0 +1,216 @@
+"""
+Example: Multi-symbol alpha selection.
+
+Demonstrates the two AlphaSelector APIs that are absent from other examples:
+
+  AlphaSelector.suggest_for_universe()
+    — runs suggest_indicators() on each symbol independently, then returns
+      the deduplicated union so the shared feature set captures alpha from
+      every symbol.
+
+  converters.results_to_pipeline_config()
+    — converts a list of AlphaResult objects directly into the indicator-spec
+      format expected by DataProcessor.data_processing_pipeline(). Supports
+      top_n filtering, metric ranking, and deduplicate=True to keep only the
+      best parameterisation per indicator name.
+
+Note: This example uses synthetic data so it runs without any API keys.
+"""
+
+import numpy as np
+import pandas as pd
+from rich.console import Console
+from rich.table import Table
+
+from quantrl_lab.alpha_research import INDICATOR_STRATEGY_MAP
+from quantrl_lab.alpha_research.converters import results_to_pipeline_config
+from quantrl_lab.alpha_research.models import AlphaJob
+from quantrl_lab.alpha_research.runner import AlphaRunner
+from quantrl_lab.alpha_research.selector import AlphaSelector
+
+console = Console()
+
+
+# ── Synthetic universe ─────────────────────────────────────────────────────
+
+
+def make_ohlcv(n: int = 252, seed: int = 0) -> pd.DataFrame:
+    """Synthetic daily OHLCV DataFrame."""
+    np.random.seed(seed)
+    close = 100 * np.exp(np.cumsum(np.random.randn(n) * 0.015))
+    return pd.DataFrame(
+        {
+            'Open': close * (1 + np.random.randn(n) * 0.003),
+            'High': close * (1 + np.abs(np.random.randn(n) * 0.007)),
+            'Low': close * (1 - np.abs(np.random.randn(n) * 0.007)),
+            'Close': close,
+            'Volume': np.random.randint(500_000, 5_000_000, n),
+        },
+        index=pd.date_range('2023-01-01', periods=n, freq='B'),
+    )
+
+
+# A small universe of three synthetic symbols
+UNIVERSE: dict[str, pd.DataFrame] = {
+    'SYM_A': make_ohlcv(seed=1),
+    'SYM_B': make_ohlcv(seed=2),
+    'SYM_C': make_ohlcv(seed=3),
+}
+
+# Restrict candidates to a fast subset so the example runs quickly
+FAST_CANDIDATES = [
+    {'name': 'RSI', 'params': {'window': 14}},
+    {'name': 'SMA', 'params': {'window': 20}},
+    {'name': 'EMA', 'params': {'window': 20}},
+    {'name': 'MACD', 'params': {'fast': 12, 'slow': 26, 'signal': 9}},
+    {'name': 'ATR', 'params': {'window': 14}},
+]
+
+
+# ── 1. suggest_for_universe() ──────────────────────────────────────────────
+
+
+def demo_suggest_for_universe():
+    console.rule('[bold cyan]1. AlphaSelector.suggest_for_universe()[/bold cyan]')
+
+    console.print(f'Universe: {list(UNIVERSE.keys())}  |  ' f'Candidates tested per symbol: {len(FAST_CANDIDATES)}\n')
+
+    # suggest_for_universe is a classmethod — no instance needed.
+    # It runs suggest_indicators() on each symbol, then returns the
+    # deduplicated union so any alpha found for any symbol is included.
+    selected = AlphaSelector.suggest_for_universe(
+        raw_data=UNIVERSE,
+        candidates=FAST_CANDIDATES,
+        metric='ic',
+        threshold=0.0,  # keep everything for demonstration
+        top_k=3,  # top-3 per symbol before dedup
+        verbose=True,
+        selection_mode='feature',
+    )
+
+    console.print('\n[green]Deduplicated indicators selected across universe:[/green]')
+    for spec in selected:
+        console.print(f'  {spec}')
+
+    console.print(
+        '\n[dim]These specs are ready to pass directly to '
+        'DataProcessor.data_processing_pipeline(indicators=selected)[/dim]\n'
+    )
+    return selected
+
+
+# ── 2. results_to_pipeline_config() direct usage ──────────────────────────
+
+
+def demo_results_to_pipeline_config():
+    console.rule('[bold cyan]2. converters.results_to_pipeline_config()[/bold cyan]')
+
+    # Build a small batch of jobs with multiple windows per indicator
+    data = UNIVERSE['SYM_A']
+    runner = AlphaRunner(verbose=False)
+
+    jobs = []
+    for indicator, windows in [
+        ('RSI', [7, 14, 21]),
+        ('SMA', [20, 50]),
+        ('EMA', [12, 26]),
+    ]:
+        strategy_config = INDICATOR_STRATEGY_MAP[indicator]
+        for w in windows:
+            jobs.append(
+                AlphaJob(
+                    data=data,
+                    indicator_name=indicator,
+                    indicator_params={'window': w},
+                    strategy_name=strategy_config['name'],
+                    strategy_params=strategy_config['params'],
+                )
+            )
+
+    results = runner.run_batch(jobs, n_jobs=1)
+    completed = [r for r in results if r.status == 'completed']
+    console.print(f'Ran {len(jobs)} jobs → {len(completed)} completed\n')
+
+    # ── Without deduplication ────────────────────────────────────────────
+    cfg_all = results_to_pipeline_config(completed, top_n=10, metric='ic', deduplicate=False)
+    console.print(f'[yellow]Without deduplicate:[/yellow] {len(cfg_all)} specs')
+    for spec in cfg_all:
+        console.print(f'  {spec}')
+
+    # ── With deduplication: best window per indicator name ───────────────
+    console.print()
+    cfg_dedup = results_to_pipeline_config(completed, top_n=10, metric='ic', deduplicate=True)
+    console.print(f'[green]With deduplicate=True:[/green] {len(cfg_dedup)} specs (one per indicator)')
+    for spec in cfg_dedup:
+        console.print(f'  {spec}')
+
+    # ── top_n applied after dedup ────────────────────────────────────────
+    console.print()
+    cfg_top1 = results_to_pipeline_config(completed, top_n=1, metric='ic', deduplicate=True)
+    console.print(f'[green]top_n=1 after dedup:[/green] {cfg_top1}\n')
+
+    # ── Show the DataProcessor call these specs feed into ─────────────────
+    console.print(
+        '[dim]Usage:\n'
+        '  from quantrl_lab.data.processing import DataProcessor\n'
+        '  processor = DataProcessor(ohlcv_data=df)\n'
+        '  processed, metadata = processor.data_processing_pipeline(indicators=cfg_dedup)[/dim]\n'
+    )
+
+    return cfg_dedup
+
+
+# ── 3. Per-symbol selection summary table ─────────────────────────────────
+
+
+def demo_per_symbol_comparison():
+    console.rule('[bold cyan]3. Per-symbol selection comparison[/bold cyan]')
+
+    table = Table(title='Best indicator per symbol (IC metric)')
+    table.add_column('Symbol', style='magenta')
+    table.add_column('Indicator')
+    table.add_column('Params')
+    table.add_column('IC', justify='right')
+    table.add_column('Sharpe', justify='right')
+
+    runner = AlphaRunner(verbose=False)
+
+    for symbol, df in UNIVERSE.items():
+        jobs = [
+            AlphaJob(
+                data=df,
+                indicator_name=cand['name'],
+                indicator_params=cand['params'],
+                strategy_name=INDICATOR_STRATEGY_MAP[cand['name']]['name'],
+                strategy_params=INDICATOR_STRATEGY_MAP[cand['name']]['params'],
+            )
+            for cand in FAST_CANDIDATES
+        ]
+        results = runner.run_batch(jobs, n_jobs=1)
+        completed = [r for r in results if r.status == 'completed']
+
+        if not completed:
+            continue
+
+        best = max(completed, key=lambda r: r.metrics.get('ic', -999))
+        table.add_row(
+            symbol,
+            best.job.indicator_name,
+            str(best.job.indicator_params),
+            f"{best.metrics.get('ic', 0):.4f}",
+            f"{best.metrics.get('sharpe_ratio', 0):.2f}",
+        )
+
+    console.print(table)
+
+
+def main():
+    demo_suggest_for_universe()
+    demo_results_to_pipeline_config()
+    demo_per_symbol_comparison()
+
+    console.print('[green]Multi-symbol selection demo complete.[/green]')
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/alpha_research/run_alpha_workflow.py
+++ b/examples/alpha_research/run_alpha_workflow.py
@@ -42,7 +42,7 @@ def main():
     # ── 2. Select best indicators via AlphaSelector ───────────────────────────
     console.rule("[bold cyan]Step 1: Indicator Selection[/bold cyan]")
     selector = AlphaSelector(data)
-    selected = selector.suggest_indicators(metric="ic", threshold=0.02, top_k=5)
+    selected = selector.suggest_indicators(metric="ic", threshold=0.02, top_k=5, selection_mode="feature")
 
     if not selected:
         console.print("[yellow]No indicators passed the IC threshold. Using defaults.[/yellow]")

--- a/examples/alpha_research/signal_metrics.py
+++ b/examples/alpha_research/signal_metrics.py
@@ -1,0 +1,266 @@
+"""
+Example: Signal Metrics and Score Generation.
+
+Demonstrates the signal-quality utilities that are distinct from a full
+AlphaRunner job:
+
+  - generate_scores()           — continuous alpha scores from any strategy
+  - analyze_signal()            — one-call IC / Rank-IC / autocorr / turnover
+  - calculate_pearson_ic()      — Pearson IC with p-value
+  - calculate_rank_ic()         — Spearman Rank IC with p-value
+  - calculate_forward_returns() — forward-return series construction
+  - AlphaJob.tags               — tagging jobs for grouping / filtering
+  - allow_short=False           — long-only mode on AlphaJob / AlphaRunner
+"""
+
+import numpy as np
+import pandas as pd
+from rich.console import Console
+from rich.table import Table
+
+from quantrl_lab.alpha_research.alpha_strategies import (
+    MACDCrossoverStrategy,
+    MeanReversionStrategy,
+    TrendFollowingStrategy,
+)
+from quantrl_lab.alpha_research.metrics import (
+    analyze_signal,
+    calculate_forward_returns,
+    calculate_pearson_ic,
+    calculate_rank_ic,
+)
+from quantrl_lab.alpha_research.models import AlphaJob, AlphaResult
+from quantrl_lab.alpha_research.runner import AlphaRunner
+
+console = Console()
+
+
+# ── Synthetic data fixture ─────────────────────────────────────────────────
+
+
+def make_ohlcv(n: int = 252, seed: int = 42) -> pd.DataFrame:
+    """Return a year of synthetic daily OHLCV data."""
+    np.random.seed(seed)
+    close = 100 * np.exp(np.cumsum(np.random.randn(n) * 0.015))
+    return pd.DataFrame(
+        {
+            'Open': close * (1 + np.random.randn(n) * 0.003),
+            'High': close * (1 + np.abs(np.random.randn(n) * 0.007)),
+            'Low': close * (1 - np.abs(np.random.randn(n) * 0.007)),
+            'Close': close,
+            'Volume': np.random.randint(500_000, 5_000_000, n),
+        },
+        index=pd.date_range('2023-01-01', periods=n, freq='B'),
+    )
+
+
+# ── 1. generate_scores() ──────────────────────────────────────────────────
+
+
+def demo_generate_scores(data: pd.DataFrame):
+    console.rule('[bold cyan]1. generate_scores()[/bold cyan]')
+
+    # Add indicators manually so we can show scores from multiple strategies
+    sma = data['Close'].rolling(20).mean()
+    rsi_delta = data['Close'].diff()
+    gain = rsi_delta.where(rsi_delta > 0, 0).rolling(14).mean()
+    loss = (-rsi_delta.where(rsi_delta < 0, 0)).rolling(14).mean()
+    rsi = 100 - (100 / (1 + gain / loss))
+
+    fast_ema = data['Close'].ewm(span=12, adjust=False).mean()
+    slow_ema = data['Close'].ewm(span=26, adjust=False).mean()
+
+    df = data.copy()
+    df['SMA_20'] = sma
+    df['RSI_14'] = rsi
+    df['MACD_line'] = fast_ema - slow_ema
+    df['MACD_signal'] = df['MACD_line'].ewm(span=9, adjust=False).mean()
+    df = df.dropna()
+
+    strategies = {
+        'TrendFollowing(SMA_20)': TrendFollowingStrategy(indicator_col='SMA_20'),
+        'MeanReversion(RSI_14)': MeanReversionStrategy(indicator_col='RSI_14'),
+        'MACDCrossover': MACDCrossoverStrategy(fast_col='MACD_line', slow_col='MACD_signal'),
+    }
+
+    table = Table(title='Score statistics (last 50 bars)')
+    table.add_column('Strategy', style='magenta')
+    table.add_column('Min', justify='right')
+    table.add_column('Max', justify='right')
+    table.add_column('Mean', justify='right')
+    table.add_column('Std', justify='right')
+
+    for label, strat in strategies.items():
+        scores = strat.generate_scores(df).iloc[-50:]
+        table.add_row(
+            label,
+            f'{scores.min():.3f}',
+            f'{scores.max():.3f}',
+            f'{scores.mean():.3f}',
+            f'{scores.std():.3f}',
+        )
+
+    console.print(table)
+    console.print('[dim]Scores are always clipped to [-1, 1].[/dim]\n')
+
+
+# ── 2. analyze_signal() ───────────────────────────────────────────────────
+
+
+def demo_analyze_signal(data: pd.DataFrame):
+    console.rule('[bold cyan]2. analyze_signal() — one-call signal quality[/bold cyan]')
+
+    sma = data['Close'].rolling(20).mean()
+    signal = (data['Close'] - sma).fillna(0)  # simple price-vs-SMA distance
+
+    # analyze_signal rank-normalises the signal by default and computes
+    # IC, Rank-IC, autocorrelation, and turnover in one call.
+    metrics = analyze_signal(
+        signal=signal,
+        prices=data['Close'],
+        forward_periods=5,
+        normalize=True,
+    )
+
+    table = Table(title='analyze_signal() output (SMA-distance signal, 5-day horizon)')
+    table.add_column('Metric', style='magenta')
+    table.add_column('Value', justify='right')
+
+    for k, v in metrics.items():
+        table.add_row(k, f'{v:.4f}' if isinstance(v, float) else str(v))
+
+    console.print(table)
+    console.print()
+
+
+# ── 3. calculate_pearson_ic / calculate_rank_ic ───────────────────────────
+
+
+def demo_ic_functions(data: pd.DataFrame):
+    console.rule('[bold cyan]3. calculate_pearson_ic / calculate_rank_ic[/bold cyan]')
+
+    fwd_returns = calculate_forward_returns(data['Close'], periods=5)
+
+    sma20 = data['Close'].rolling(20).mean()
+    sma_signal = (data['Close'] - sma20).dropna()
+
+    # Align
+    valid = sma_signal.index.intersection(fwd_returns.dropna().index)
+    s = sma_signal.loc[valid]
+    r = fwd_returns.loc[valid]
+
+    ic, ic_p = calculate_pearson_ic(s, r)
+    rank_ic, rank_p = calculate_rank_ic(s, r)
+
+    console.print(f'  Pearson IC:  {ic:.4f}  (p={ic_p:.4f})')
+    console.print(f'  Rank IC:     {rank_ic:.4f}  (p={rank_p:.4f})')
+    console.print('[dim]IC near 0 is expected for synthetic random-walk data.[/dim]\n')
+
+    # Edge-case: constant signal → returns 0.0 instead of NaN
+    const_signal = pd.Series([1.0] * len(r), index=r.index)
+    ic_const, p_const = calculate_pearson_ic(const_signal, r)
+    console.print(f'  Constant signal → IC={ic_const}  p={p_const}  (no NaN propagation)\n')
+
+
+# ── 4. AlphaJob.tags + allow_short=False ─────────────────────────────────
+
+
+def demo_tags_and_long_only(data: pd.DataFrame):
+    console.rule('[bold cyan]4. AlphaJob.tags and allow_short=False[/bold cyan]')
+
+    runner = AlphaRunner(verbose=False)
+
+    # Tags are free-form key-value strings — useful for grouping batch results
+    jobs = [
+        AlphaJob(
+            data=data,
+            indicator_name='RSI',
+            strategy_name='mean_reversion',
+            indicator_params={'window': w},
+            allow_short=False,  # long-only: SELL signals are suppressed
+            tags={'category': 'momentum', 'window': str(w)},
+        )
+        for w in (7, 14, 21)
+    ]
+
+    results = runner.run_batch(jobs, n_jobs=1)
+
+    table = Table(title='Long-only RSI jobs (allow_short=False)')
+    table.add_column('Window', justify='right')
+    table.add_column('Tags')
+    table.add_column('Status')
+    table.add_column('Sharpe', justify='right')
+    table.add_column('Total return', justify='right')
+
+    for r in results:
+        table.add_row(
+            str(r.job.indicator_params.get('window', '?')),
+            str(r.job.tags),
+            r.status,
+            f"{r.metrics.get('sharpe_ratio', 0):.2f}" if r.status == 'completed' else '-',
+            f"{r.metrics.get('total_return', 0):.2%}" if r.status == 'completed' else '-',
+        )
+
+    console.print(table)
+
+    # Demonstrate filtering by tag
+    momentum_results = [r for r in results if r.job.tags.get('category') == 'momentum']
+    console.print(f'\nFiltered by tag category=momentum: {len(momentum_results)} results\n')
+
+
+# ── 5. Signals vs. Scores side-by-side from AlphaRunner ──────────────────
+
+
+def demo_signals_vs_scores(data: pd.DataFrame):
+    console.rule('[bold cyan]5. Signals vs. Scores from a completed AlphaResult[/bold cyan]')
+
+    runner = AlphaRunner(verbose=False)
+    strategy_job = AlphaJob(
+        data=data,
+        indicator_name='RSI',
+        strategy_name='mean_reversion',
+        indicator_params={'window': 14},
+        allow_short=True,
+    )
+    feature_job = AlphaJob(
+        data=data,
+        indicator_name='RSI',
+        strategy_name='mean_reversion',
+        indicator_params={'window': 14},
+        evaluation_mode='feature',
+    )
+    strategy_result: AlphaResult = runner.run_job(strategy_job)
+    feature_result: AlphaResult = runner.run_job(feature_job)
+
+    if strategy_result.status != 'completed':
+        console.print(f'[red]Strategy job failed: {strategy_result.error}[/red]')
+        return
+    if feature_result.status != 'completed':
+        console.print(f'[red]Feature job failed: {feature_result.error}[/red]')
+        return
+
+    sig_counts = strategy_result.signals.value_counts().to_dict()
+    scores = feature_result.scores.dropna()
+
+    console.print(f'  Strategy-mode signal distribution: {sig_counts}')
+    console.print(f'  Feature-mode score range: [{scores.min():.3f}, {scores.max():.3f}]  ' f'mean={scores.mean():.3f}')
+    console.print(
+        f"  Feature-mode IC: {feature_result.metrics.get('ic', 0):.4f}  "
+        f"Strategy-mode Sharpe: {strategy_result.metrics.get('sharpe_ratio', 0):.2f}\n"
+    )
+
+
+def main():
+    data = make_ohlcv()
+
+    demo_generate_scores(data)
+    demo_analyze_signal(data)
+    demo_ic_functions(data)
+    demo_tags_and_long_only(data)
+    demo_signals_vs_scores(data)
+
+    console.print('[green]All signal-metrics demos complete.[/green]')
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/end_to_end/single_asset/train_shared_policy.py
+++ b/examples/end_to_end/single_asset/train_shared_policy.py
@@ -1,0 +1,806 @@
+"""
+Shared-policy multi-symbol training script.
+
+Trains a single shared policy across multiple symbols simultaneously,
+so the agent learns to generalise across tickers rather than overfit to one.
+Supports all algorithms via ``--algo``:
+  SAC, PPO, A2C, TD3, TQC, TRPO, CrossQ, RecurrentPPO
+
+On-policy algorithms (PPO, A2C, TRPO, RecurrentPPO) use SubprocVecEnv with
+one subprocess per symbol — parallel rollouts are pooled into a single buffer.
+
+Off-policy algorithms (SAC, TD3, TQC, CrossQ) use a single env with panel
+data (all symbols concatenated), so the replay buffer samples transitions
+across all tickers.
+
+Usage::
+
+    python train_multi_symbol.py --algo SAC
+    python train_multi_symbol.py --algo RecurrentPPO --total-timesteps 1000000
+    python train_multi_symbol.py --algo TD3 --period-years 3
+    python train_multi_symbol.py --algo TQC --algorithm-config '{"learning_rate": 3e-4}'
+
+Shared infrastructure (data-source init, date helpers) lives in
+``examples/end_to_end/shared/data_utils.py``.
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import warnings
+from dataclasses import dataclass
+from time import perf_counter
+from typing import Any, Dict, List, Optional, Tuple
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import aiohttp  # noqa: E402
+from dotenv import load_dotenv  # noqa: E402
+from rich.console import Console  # noqa: E402
+from rich.table import Table  # noqa: E402
+
+load_dotenv()
+warnings.filterwarnings('ignore')
+console = Console()
+
+import pandas as pd  # noqa: E402
+from shared.data_utils import (  # noqa: E402
+    DataSources,
+    get_date_range,
+    init_data_sources,
+)
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class RunConfig:
+    """Top-level experiment configuration."""
+
+    algo: str = 'RecurrentPPO'
+    symbols: List[str] = None  # defaults to DEFAULT_SYMBOLS
+    period_years: int = 2
+    window_size: int = 10
+    total_timesteps: int = 1_000_000
+    algorithm_config: Optional[Dict[str, Any]] = None  # overrides/merges with preset
+
+    def __post_init__(self):
+        if self.symbols is None:
+            self.symbols = list(DEFAULT_SYMBOLS)
+
+
+DEFAULT_SYMBOLS = [
+    'AAPL',
+    'MSFT',
+    'GOOG',
+    'AMZN',
+    'JPM',
+    'JNJ',
+    'PG',
+    'XOM',
+    'CAT',
+]
+
+
+@dataclass
+class AlgorithmPreset:
+    """
+    Algorithm-specific configuration.
+
+    ``n_envs_from_symbols``: if True, n_envs is set to the number of symbols
+    (one subprocess per ticker) — valid for on-policy algorithms only.
+    If False, n_envs=1 (off-policy: single env with panel data).
+    """
+
+    algo_class_factory: Any
+    algorithm_config_factory: Any
+    reward_factory: Any
+    n_envs_from_symbols: bool = False  # True → on-policy; False → off-policy
+    description: str = ''
+
+
+def _make_presets() -> Dict[str, AlgorithmPreset]:
+
+    # ── Off-policy ─────────────────────────────────────────────────────────────
+
+    def sac_class():
+        from stable_baselines3 import SAC
+
+        return SAC
+
+    def sac_config():
+        return dict(
+            policy='MlpPolicy',
+            learning_rate=1e-4,
+            buffer_size=500_000,
+            learning_starts=10_000,
+            batch_size=512,
+            tau=0.005,
+            gamma=0.99,
+            train_freq=4,
+            gradient_steps=2,
+            ent_coef='auto',
+            policy_kwargs=dict(net_arch=dict(pi=[256, 256], qf=[256, 256])),
+            verbose=0,
+        )
+
+    def sac_reward():
+        from quantrl_lab.environments.stock.strategies.rewards.sharpe import DifferentialSharpeReward
+
+        return DifferentialSharpeReward(risk_free_rate=0.0)
+
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def td3_class():
+        from stable_baselines3 import TD3
+
+        return TD3
+
+    def td3_config():
+        import numpy as np
+        from stable_baselines3.common.noise import NormalActionNoise
+
+        action_noise = NormalActionNoise(mean=np.zeros(3), sigma=0.1 * np.ones(3))
+        return dict(
+            policy='MlpPolicy',
+            learning_rate=1e-4,
+            buffer_size=500_000,
+            learning_starts=20_000,
+            batch_size=256,
+            tau=0.005,
+            gamma=0.995,
+            train_freq=8,
+            gradient_steps=2,
+            policy_delay=2,
+            target_policy_noise=0.2,
+            target_noise_clip=0.5,
+            action_noise=action_noise,
+            policy_kwargs=dict(net_arch=[256, 256]),
+            verbose=0,
+        )
+
+    def td3_reward():
+        from quantrl_lab.environments.stock.strategies.rewards.composite import CompositeReward
+        from quantrl_lab.environments.stock.strategies.rewards.portfolio_value import PortfolioValueChangeReward
+        from quantrl_lab.environments.stock.strategies.rewards.turnover import TurnoverPenaltyReward
+
+        return CompositeReward(
+            strategies=[PortfolioValueChangeReward(), TurnoverPenaltyReward(penalty_factor=0.1)],
+            weights=[1.0, 0.05],
+            auto_scale=False,
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def tqc_class():
+        from sb3_contrib import TQC
+
+        return TQC
+
+    def tqc_config():
+        return dict(
+            policy='MlpPolicy',
+            learning_rate=3e-4,
+            buffer_size=500_000,
+            learning_starts=20_000,
+            batch_size=256,
+            tau=0.005,
+            gamma=0.99,
+            train_freq=8,
+            gradient_steps=2,
+            ent_coef='auto',
+            top_quantiles_to_drop_per_net=2,
+            policy_kwargs=dict(net_arch=[256, 256], n_quantiles=25),
+            verbose=0,
+        )
+
+    def tqc_reward():
+        from quantrl_lab.environments.stock.strategies.rewards.composite import CompositeReward
+        from quantrl_lab.environments.stock.strategies.rewards.portfolio_value import PortfolioValueChangeReward
+        from quantrl_lab.environments.stock.strategies.rewards.turnover import TurnoverPenaltyReward
+
+        return CompositeReward(
+            strategies=[PortfolioValueChangeReward(), TurnoverPenaltyReward(penalty_factor=0.01)],
+            weights=[1.0, 0.05],
+            auto_scale=True,
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def crossq_class():
+        from sb3_contrib import CrossQ
+
+        return CrossQ
+
+    def crossq_config():
+        return dict(
+            policy='MlpPolicy',
+            learning_rate=1e-4,
+            buffer_size=500_000,
+            learning_starts=1_000,
+            batch_size=256,
+            tau=0.005,
+            gamma=0.99,
+            train_freq=4,
+            gradient_steps=1,
+            ent_coef='auto',
+            policy_kwargs=dict(net_arch=[256, 256]),
+            verbose=0,
+        )
+
+    def crossq_reward():
+        from quantrl_lab.environments.stock.strategies.rewards.composite import CompositeReward
+        from quantrl_lab.environments.stock.strategies.rewards.portfolio_value import PortfolioValueChangeReward
+        from quantrl_lab.environments.stock.strategies.rewards.turnover import TurnoverPenaltyReward
+
+        return CompositeReward(
+            strategies=[PortfolioValueChangeReward(), TurnoverPenaltyReward(penalty_factor=0.1)],
+            weights=[1.0, 0.05],
+            auto_scale=False,
+        )
+
+    # ── On-policy ──────────────────────────────────────────────────────────────
+
+    def recurrent_ppo_class():
+        from sb3_contrib import RecurrentPPO
+
+        return RecurrentPPO
+
+    def recurrent_ppo_config():
+        return dict(
+            policy='MlpLstmPolicy',
+            ent_coef=0.05,
+            learning_rate=2e-4,
+            n_steps=2048,
+            batch_size=128,
+            clip_range=0.1,
+            max_grad_norm=0.5,
+            gamma=0.95,
+            gae_lambda=0.95,
+            policy_kwargs=dict(
+                net_arch=dict(pi=[64, 64], vf=[64, 64]),
+                lstm_hidden_size=64,
+                n_lstm_layers=1,
+                enable_critic_lstm=False,
+            ),
+            verbose=0,
+        )
+
+    def recurrent_ppo_reward():
+        from quantrl_lab.environments.stock.strategies.rewards.composite import CompositeReward
+        from quantrl_lab.environments.stock.strategies.rewards.drawdown import DrawdownPenaltyReward
+        from quantrl_lab.environments.stock.strategies.rewards.execution_bonus import LimitExecutionReward
+        from quantrl_lab.environments.stock.strategies.rewards.invalid_action import InvalidActionPenalty
+        from quantrl_lab.environments.stock.strategies.rewards.sortino import DifferentialSortinoReward
+        from quantrl_lab.environments.stock.strategies.rewards.turnover import TurnoverPenaltyReward
+
+        return CompositeReward(
+            strategies=[
+                DifferentialSortinoReward(),
+                DrawdownPenaltyReward(penalty_factor=0.5),
+                TurnoverPenaltyReward(penalty_factor=0.1),
+                LimitExecutionReward(improvement_multiplier=2.0),
+                InvalidActionPenalty(penalty=-0.1),
+            ],
+            weights=[1.0, 0.2, 0.1, 0.05, 0.05],
+            auto_scale=True,
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def ppo_class():
+        from stable_baselines3 import PPO
+
+        return PPO
+
+    def ppo_config():
+        return dict(
+            policy='MlpPolicy',
+            ent_coef=0.01,
+            learning_rate=3e-4,
+            n_steps=1024,
+            batch_size=128,
+            gamma=0.98,
+            clip_range=0.1,
+            gae_lambda=0.95,
+            verbose=0,
+        )
+
+    def ppo_reward():
+        from quantrl_lab.environments.stock.strategies.rewards.composite import CompositeReward
+        from quantrl_lab.environments.stock.strategies.rewards.invalid_action import InvalidActionPenalty
+        from quantrl_lab.environments.stock.strategies.rewards.portfolio_value import PortfolioValueChangeReward
+        from quantrl_lab.environments.stock.strategies.rewards.turnover import TurnoverPenaltyReward
+
+        return CompositeReward(
+            strategies=[
+                PortfolioValueChangeReward(),
+                TurnoverPenaltyReward(penalty_factor=0.01),
+                InvalidActionPenalty(penalty=-0.1),
+            ],
+            weights=[1.0, 0.05, 0.5],
+            auto_scale=True,
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def a2c_class():
+        from stable_baselines3 import A2C
+
+        return A2C
+
+    def a2c_config():
+        return dict(
+            policy='MlpPolicy',
+            learning_rate=7e-4,
+            n_steps=5,
+            gamma=0.99,
+            gae_lambda=1.0,
+            ent_coef=0.1,
+            vf_coef=0.5,
+            max_grad_norm=0.5,
+            rms_prop_eps=1e-5,
+            verbose=0,
+        )
+
+    def a2c_reward():
+        from quantrl_lab.environments.stock.strategies.rewards.composite import CompositeReward
+        from quantrl_lab.environments.stock.strategies.rewards.portfolio_value import PortfolioValueChangeReward
+
+        return CompositeReward(
+            strategies=[PortfolioValueChangeReward()],
+            weights=[1.0],
+            auto_scale=False,
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def trpo_class():
+        from sb3_contrib import TRPO
+
+        return TRPO
+
+    def trpo_config():
+        return dict(
+            policy='MlpPolicy',
+            learning_rate=1e-3,
+            n_steps=2048,
+            batch_size=128,
+            gamma=0.99,
+            gae_lambda=0.95,
+            cg_max_steps=15,
+            target_kl=0.01,
+            ent_coef=0.01,
+            policy_kwargs=dict(net_arch=dict(pi=[128, 128], vf=[128, 128])),
+            verbose=0,
+        )
+
+    def trpo_reward():
+        from quantrl_lab.environments.stock.strategies.rewards.composite import CompositeReward
+        from quantrl_lab.environments.stock.strategies.rewards.drawdown import DrawdownPenaltyReward
+        from quantrl_lab.environments.stock.strategies.rewards.sortino import DifferentialSortinoReward
+        from quantrl_lab.environments.stock.strategies.rewards.turnover import TurnoverPenaltyReward
+
+        return CompositeReward(
+            strategies=[
+                DifferentialSortinoReward(),
+                DrawdownPenaltyReward(penalty_factor=0.5),
+                TurnoverPenaltyReward(penalty_factor=0.1),
+            ],
+            weights=[1.0, 0.2, 0.1],
+            auto_scale=True,
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+
+    return {
+        'SAC': AlgorithmPreset(
+            algo_class_factory=sac_class,
+            algorithm_config_factory=sac_config,
+            reward_factory=sac_reward,
+            n_envs_from_symbols=False,
+            description='Off-policy, max-entropy. Panel env, single replay buffer.',
+        ),
+        'TD3': AlgorithmPreset(
+            algo_class_factory=td3_class,
+            algorithm_config_factory=td3_config,
+            reward_factory=td3_reward,
+            n_envs_from_symbols=False,
+            description='Off-policy, deterministic. Panel env, single replay buffer.',
+        ),
+        'TQC': AlgorithmPreset(
+            algo_class_factory=tqc_class,
+            algorithm_config_factory=tqc_config,
+            reward_factory=tqc_reward,
+            n_envs_from_symbols=False,
+            description='Off-policy, distributional Q. Panel env, single replay buffer.',
+        ),
+        'CrossQ': AlgorithmPreset(
+            algo_class_factory=crossq_class,
+            algorithm_config_factory=crossq_config,
+            reward_factory=crossq_reward,
+            n_envs_from_symbols=False,
+            description='Off-policy, batch-norm critic. Panel env, single replay buffer.',
+        ),
+        'RecurrentPPO': AlgorithmPreset(
+            algo_class_factory=recurrent_ppo_class,
+            algorithm_config_factory=recurrent_ppo_config,
+            reward_factory=recurrent_ppo_reward,
+            n_envs_from_symbols=True,
+            description='On-policy, LSTM. One subprocess per symbol via SubprocVecEnv.',
+        ),
+        'PPO': AlgorithmPreset(
+            algo_class_factory=ppo_class,
+            algorithm_config_factory=ppo_config,
+            reward_factory=ppo_reward,
+            n_envs_from_symbols=True,
+            description='On-policy, clipped surrogate. One subprocess per symbol.',
+        ),
+        'A2C': AlgorithmPreset(
+            algo_class_factory=a2c_class,
+            algorithm_config_factory=a2c_config,
+            reward_factory=a2c_reward,
+            n_envs_from_symbols=True,
+            description='On-policy actor-critic. One subprocess per symbol.',
+        ),
+        'TRPO': AlgorithmPreset(
+            algo_class_factory=trpo_class,
+            algorithm_config_factory=trpo_config,
+            reward_factory=trpo_reward,
+            n_envs_from_symbols=True,
+            description='On-policy, trust-region. One subprocess per symbol.',
+        ),
+    }
+
+
+PRESETS: Dict[str, AlgorithmPreset] = _make_presets()
+
+
+# ── Async data fetching ────────────────────────────────────────────────────────
+
+
+async def _fetch_enrichment_for_symbol(
+    session: aiohttp.ClientSession,
+    fmp: Optional[Any],
+    alpaca: Optional[Any],
+    symbol: str,
+    start_date,
+    end_date,
+) -> Dict[str, Any]:
+    """
+    Concurrently fetch all optional enrichment data for a single symbol.
+
+    Returns a dict with keys: symbol, ratings_df, sector_perf_df,
+    industry_perf_df, news_df. All values default to None on failure.
+    """
+    result: Dict[str, Any] = {
+        'symbol': symbol,
+        'ratings_df': None,
+        'sector_perf_df': None,
+        'industry_perf_df': None,
+        'news_df': None,
+    }
+
+    start_str = start_date.strftime('%Y-%m-%d')
+    end_str = end_date.strftime('%Y-%m-%d')
+
+    fmp_tasks = []
+    if fmp:
+        fmp_tasks = [
+            fmp.async_fetch_ratings(session, symbol, limit=500),
+            fmp.async_fetch_company_profile(session, symbol),
+        ]
+
+    alpaca_task = None
+    if alpaca:
+        alpaca_task = alpaca.async_fetch_news(session, symbol, start_date, end_date)
+
+    all_tasks = fmp_tasks + ([alpaca_task] if alpaca_task else [])
+    if not all_tasks:
+        return result
+
+    outcomes = await asyncio.gather(*all_tasks, return_exceptions=True)
+
+    idx = 0
+    if fmp:
+        if not isinstance(outcomes[idx], Exception):
+            _, result['ratings_df'] = outcomes[idx]
+        idx += 1
+        if not isinstance(outcomes[idx], Exception):
+            _, profile_df = outcomes[idx]
+            if not profile_df.empty:
+                sector = profile_df.iloc[0].get('sector')
+                industry = profile_df.iloc[0].get('industry')
+                sector_tasks = []
+                if sector:
+                    sector_tasks.append(fmp.async_fetch_sector_perf(session, sector, start_str, end_str))
+                if industry:
+                    sector_tasks.append(fmp.async_fetch_industry_perf(session, industry, start_str, end_str))
+                if sector_tasks:
+                    sector_outcomes = await asyncio.gather(*sector_tasks, return_exceptions=True)
+                    si = 0
+                    if sector and not isinstance(sector_outcomes[si], Exception):
+                        _, result['sector_perf_df'] = sector_outcomes[si]
+                        si += 1
+                    if industry and si < len(sector_outcomes) and not isinstance(sector_outcomes[si], Exception):
+                        _, result['industry_perf_df'] = sector_outcomes[si]
+        idx += 1
+
+    if alpaca_task and not isinstance(outcomes[idx], Exception):
+        _, result['news_df'] = outcomes[idx]
+
+    return result
+
+
+async def _fetch_all_symbol_data(
+    symbols: List[str],
+    sources: DataSources,
+    start_date,
+    end_date,
+) -> Tuple[Dict[str, pd.DataFrame], Dict[str, Dict]]:
+    """
+    Concurrently fetch OHLCV and optional enrichment for all symbols.
+
+    Returns:
+        raw_data:   ``{symbol: ohlcv_df}``
+        enrichment: ``{symbol: {ratings_df, sector_perf_df, ...}}``
+    """
+    async with aiohttp.ClientSession() as session:
+        console.print(f'[bold blue]Fetching OHLCV for {len(symbols)} symbols concurrently...[/bold blue]')
+        ohlcv_tasks = [sources.loader.async_fetch_ohlcv(sym, start_date, end_date) for sym in symbols]
+        ohlcv_outcomes = await asyncio.gather(*ohlcv_tasks, return_exceptions=True)
+
+        raw_data: Dict[str, pd.DataFrame] = {}
+        for outcome in ohlcv_outcomes:
+            if isinstance(outcome, Exception):
+                console.print(f'[red]OHLCV fetch error: {outcome}[/red]')
+                continue
+            sym, df = outcome
+            if 'Date' in df.columns:
+                df = df.set_index('Date')
+            if not df.empty:
+                raw_data[sym] = df
+            else:
+                console.print(f'[yellow]Empty OHLCV for {sym}, skipping.[/yellow]')
+
+        if not raw_data:
+            return {}, {}
+
+        enrichment: Dict[str, Dict] = {}
+        if sources.fmp or sources.alpaca:
+            console.print('[bold blue]Fetching enrichment data concurrently...[/bold blue]')
+            enrich_tasks = [
+                _fetch_enrichment_for_symbol(session, sources.fmp, sources.alpaca, sym, start_date, end_date)
+                for sym in raw_data
+            ]
+            enrich_outcomes = await asyncio.gather(*enrich_tasks, return_exceptions=True)
+            for outcome in enrich_outcomes:
+                if isinstance(outcome, Exception):
+                    console.print(f'[yellow]Enrichment fetch error: {outcome}[/yellow]')
+                    continue
+                enrichment[outcome['symbol']] = outcome
+
+    return raw_data, enrichment
+
+
+# ── Data pipeline ─────────────────────────────────────────────────────────────
+
+
+def get_multi_stock_data(cfg: RunConfig) -> pd.DataFrame:
+    """
+    Fetch and process panel data for multiple symbols with shared
+    feature engineering.
+
+    Args:
+        cfg: RunConfig with symbols and period_years.
+
+    Returns:
+        Panel DataFrame (DatetimeIndex) with a ``Symbol`` column and a shared
+        feature set across all symbols.
+    """
+    console.print('[bold blue]Starting Multi-Stock Data Acquisition...[/bold blue]')
+
+    sources = init_data_sources()
+    start_date, end_date = get_date_range(cfg.period_years)
+
+    raw_data, enrichment = asyncio.run(_fetch_all_symbol_data(cfg.symbols, sources, start_date, end_date))
+    if not raw_data:
+        raise ValueError('No data fetched for any symbol.')
+
+    from quantrl_lab.alpha_research import AlphaSelector
+
+    console.print('[bold purple]Running Alpha Selection across all stocks (union approach)...[/bold purple]')
+    indicators = AlphaSelector.suggest_for_universe(
+        {sym: raw_df for sym, raw_df in raw_data.items()},
+        metric='ic',
+        threshold=0.02,
+        top_k=4,
+        verbose=True,
+        selection_mode='feature',
+    )
+    console.print(f'[cyan]Shared indicator set ({len(indicators)}): {indicators}[/cyan]')
+
+    from quantrl_lab.data.processing import DataProcessor
+
+    processed_dfs = []
+    for sym, raw_df in raw_data.items():
+        console.print(f'Processing [cyan]{sym}[/cyan]...')
+        try:
+            enrich = enrichment.get(sym, {})
+            processor = DataProcessor(
+                ohlcv_data=raw_df,
+                analyst_ratings=enrich.get('ratings_df'),
+                sector_performance=enrich.get('sector_perf_df'),
+                industry_performance=enrich.get('industry_perf_df'),
+                news_data=enrich.get('news_df'),
+            )
+            processed_df, _ = processor.data_processing_pipeline(indicators=indicators, verbose=False)
+            processed_df['Symbol'] = sym
+            if len(processed_df) <= cfg.window_size:
+                console.print(f'[yellow]{sym}: dataset too small after processing — skipping.[/yellow]')
+                continue
+            processed_dfs.append(processed_df)
+        except Exception as exc:
+            console.print(f'[yellow]{sym}: processing failed ({exc}) — skipping.[/yellow]')
+
+    if not processed_dfs:
+        raise ValueError('No data processed for any symbol.')
+
+    return pd.concat(processed_dfs).sort_index()
+
+
+# ── Training & Evaluation ─────────────────────────────────────────────────────
+
+
+def main(cfg: RunConfig = RunConfig()):
+    algo_key = cfg.algo
+    # Normalise casing: accept 'recurrentppo' → 'RecurrentPPO', 'sac' → 'SAC', etc.
+    for key in PRESETS:
+        if algo_key.lower() == key.lower():
+            algo_key = key
+            break
+    if algo_key not in PRESETS:
+        console.print(f'[red]Unknown algo "{cfg.algo}". Choose from: {", ".join(PRESETS)}[/red]')
+        return
+
+    preset = PRESETS[algo_key]
+    console.rule(f'[bold blue]Multi-Symbol {algo_key} Training[/bold blue]')
+    console.print(f'[dim]{preset.description}[/dim]')
+    console.print(f'Symbols: {cfg.symbols}')
+    overall_start = perf_counter()
+
+    # --- Phase 1: Data & Split ---
+    console.rule('[dim]Phase 1: Data & Split[/dim]')
+    t0 = perf_counter()
+    try:
+        full_data = get_multi_stock_data(cfg)
+    except Exception as exc:
+        console.print(f'[red]Failed to fetch/process data: {exc}[/red]')
+        import traceback
+
+        traceback.print_exc()
+        return
+
+    if 'Symbol' not in full_data.columns or len(full_data['Symbol'].unique()) < 2:
+        console.print('[red]Need at least 2 symbols in panel data. Exiting.[/red]')
+        return
+
+    unique_dates = full_data.index.unique().sort_values()
+    split_date = unique_dates[int(len(unique_dates) * 0.8)]
+    train_data = full_data[full_data.index < split_date]
+    test_data = full_data[full_data.index >= split_date]
+    data_sec = perf_counter() - t0
+    console.print(f'[cyan]Train:[/cyan] {len(train_data)} rows  [cyan]Test:[/cyan] {len(test_data)} rows')
+    console.print(f'[dim]Phase 1 duration:[/dim] {data_sec:.2f}s')
+
+    # Convert Symbol to numeric IDs for the observation space
+    symbol_to_id = {sym: float(i) for i, sym in enumerate(sorted(full_data['Symbol'].unique().tolist()))}
+    train_env_data = train_data.copy()
+    test_env_data = test_data.copy()
+    train_env_data['Symbol'] = train_env_data['Symbol'].map(symbol_to_id).astype('float32')
+    test_env_data['Symbol'] = test_env_data['Symbol'].map(symbol_to_id).astype('float32')
+
+    # --- Phase 2: Environment ---
+    console.rule('[dim]Phase 2: Environment[/dim]')
+    t0 = perf_counter()
+    from quantrl_lab.environments.stock.strategies.actions.standard import StandardActionStrategy
+    from quantrl_lab.environments.stock.strategies.observations.feature_aware import FeatureAwareObservationStrategy
+    from quantrl_lab.experiments.backtesting.builder import BacktestEnvironmentBuilder
+
+    env_config = (
+        BacktestEnvironmentBuilder()
+        .with_data(train_data=train_env_data, test_data=test_env_data)
+        .with_env_params(
+            initial_balance=100_000.0,
+            transaction_cost_pct=0.001,
+            window_size=cfg.window_size,
+        )
+        .with_strategies(
+            action=StandardActionStrategy(),
+            reward=preset.reward_factory(),
+            observation=FeatureAwareObservationStrategy(normalize_stationary=True),
+        )
+        .build()
+    )
+    env_sec = perf_counter() - t0
+    console.print(f'[dim]Phase 2 duration:[/dim] {env_sec:.2f}s')
+
+    # --- Phase 3: Training ---
+    console.rule(f'[dim]Phase 3: Training ({algo_key})[/dim]')
+    from quantrl_lab.experiments.backtesting.core import ExperimentJob
+    from quantrl_lab.experiments.backtesting.runner import BacktestRunner
+
+    n_envs = len(full_data['Symbol'].unique()) if preset.n_envs_from_symbols else 1
+
+    algo_config = preset.algorithm_config_factory()
+    if cfg.algorithm_config:
+        algo_config.update(cfg.algorithm_config)
+
+    job = ExperimentJob(
+        algorithm_class=preset.algo_class_factory(),
+        env_config=env_config,
+        algorithm_config=algo_config,
+        total_timesteps=cfg.total_timesteps,
+        n_envs=n_envs,
+    )
+
+    runner = BacktestRunner(verbose=True)
+    result = runner.run_job(job)
+
+    # --- Phase 4: Results ---
+    console.rule('[dim]Phase 4: Results[/dim]')
+    runner.inspect_result(result)
+
+    total_sec = perf_counter() - overall_start
+    phase_table = Table(title='Script Runtime Summary', show_header=True, header_style='bold green')
+    phase_table.add_column('Phase', style='cyan')
+    phase_table.add_column('Duration (s)', justify='right')
+    phase_table.add_row('1. Data', f'{data_sec:.2f}')
+    phase_table.add_row('2. Environment', f'{env_sec:.2f}')
+    phase_table.add_row('3. Training + Eval', f'{result.execution_time:.2f}')
+    phase_table.add_row('[bold]Total[/bold]', f'[bold]{total_sec:.2f}[/bold]')
+    console.print(phase_table)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Multi-symbol RL training')
+    parser.add_argument(
+        '--algo',
+        type=str,
+        default=RunConfig.algo,
+        choices=list(PRESETS),
+        help='Algorithm to use (default: %(default)s)',
+    )
+    parser.add_argument(
+        '--symbols',
+        type=str,
+        nargs='+',
+        default=None,
+        help='Space-separated list of symbols (default: 9 diversified tickers)',
+    )
+    parser.add_argument('--period-years', type=int, default=RunConfig.period_years)
+    parser.add_argument('--window-size', type=int, default=RunConfig.window_size)
+    parser.add_argument('--total-timesteps', type=int, default=RunConfig.total_timesteps)
+    parser.add_argument(
+        '--algorithm-config',
+        type=str,
+        default=None,
+        metavar='JSON',
+        help='JSON string of hyperparameter overrides, e.g. \'{"learning_rate": 3e-4}\'',
+    )
+    args = parser.parse_args()
+
+    algo_config_override = json.loads(args.algorithm_config) if args.algorithm_config else None
+
+    main(
+        RunConfig(
+            algo=args.algo,
+            symbols=args.symbols,
+            period_years=args.period_years,
+            window_size=args.window_size,
+            total_timesteps=args.total_timesteps,
+            algorithm_config=algo_config_override,
+        )
+    )

--- a/examples/end_to_end/single_asset/train_single_symbol.py
+++ b/examples/end_to_end/single_asset/train_single_symbol.py
@@ -1,214 +1,568 @@
 """
-Single-stock pipeline + training script.
+Unified single-stock training script.
 
-Validates the full workflow end-to-end on a single symbol:
-  1. Fetch OHLCV data
-  2. Alpha Research — suggest indicators
-  3. Fetch optional enrichment data (FMP, Alpaca)
-  4. Build and execute the DataPipeline  (via shared utilities)
-  5. Train/test split
-  6. Train a PPO agent
-  7. Evaluate on train and test sets
+Supports all algorithms via ``--algo``:
+  SAC, PPO, A2C, TD3, TQC, TRPO, CrossQ
 
-Shared data-loading logic lives in ``examples/end_to_end/shared/data_utils.py``.
+Each algorithm ships with a tuned preset (reward strategy + hyperparameters).
+All other settings (symbol, timesteps, window) are controlled via flags or
+by editing ``RunConfig``.
+
+Usage::
+
+    python train_single_symbol.py --algo SAC --symbol AAPL
+    python train_single_symbol.py --algo PPO --symbol MU --total-timesteps 100000
+    python train_single_symbol.py --algo TD3 --symbol NVDA --period-years 3
+
+Shared infrastructure (data-source init, date helpers) lives in
+``examples/end_to_end/shared/data_utils.py``.
 """
 
+import argparse
+import json
 import os
 import sys
+from dataclasses import dataclass
+from time import perf_counter
+from typing import Any, Dict, Optional
 
-# Allow ``python examples/end_to_end/single_asset/single_stock_training.py``
-# to resolve the shared package regardless of working directory.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from dotenv import load_dotenv  # noqa: E402
 from rich.console import Console  # noqa: E402
+from rich.table import Table  # noqa: E402
 
 load_dotenv()
 console = Console()
 
-# ── Shared utilities ──────────────────────────────────────────────────────────
 from shared.data_utils import (  # noqa: E402
     get_date_range,
     init_data_sources,
-    process_symbol,
-    select_alpha_indicators,
-    train_test_split_by_date,
 )
 
-SYMBOL = "AAPL"
-PERIOD_YEARS = 2
-WINDOW_SIZE = 40
-TOTAL_TIMESTEPS = 50_000  # small for a quick test run
+# ── Config ────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class RunConfig:
+    """Top-level experiment configuration."""
+
+    algo: str = "SAC"
+    symbol: str = "MU"
+    period_years: int = 5
+    window_size: int = 15
+    total_timesteps: int = 50_000
+    algorithm_config: Optional[Dict[str, Any]] = None  # overrides/merges with preset
+
+
+@dataclass
+class AlgorithmPreset:
+    """
+    Algorithm-specific configuration: class, hyperparameters, n_envs,
+    and a factory for the reward strategy.
+
+    ``reward_factory`` is a zero-argument callable so reward objects
+    (which may import heavy deps) are created lazily at runtime.
+    ``algorithm_config_factory`` is used instead of a plain dict for
+    algorithms like TD3 that need runtime-constructed objects
+    (e.g. ``NormalActionNoise``). For all others it just returns the
+    static dict.
+    """
+
+    algo_class_factory: Any  # zero-arg callable → algorithm class
+    algorithm_config_factory: Any  # zero-arg callable → Dict[str, Any]
+    reward_factory: Any  # zero-arg callable → reward strategy instance
+    n_envs: int = 1
+    description: str = ""
+
+
+def _make_presets() -> Dict[str, AlgorithmPreset]:
+    """Build the preset registry lazily so heavy imports only happen
+    when a preset is actually requested."""
+
+    def sac_class():
+        from stable_baselines3 import SAC
+
+        return SAC
+
+    def sac_config():
+        return dict(
+            policy='MlpPolicy',
+            learning_rate=1e-4,
+            buffer_size=100_000,
+            learning_starts=5_000,
+            batch_size=512,
+            tau=0.005,
+            gamma=0.99,
+            train_freq=1,
+            ent_coef='auto',
+            policy_kwargs=dict(net_arch=dict(pi=[128, 128], qf=[128, 128])),
+            verbose=0,
+        )
+
+    def sac_reward():
+        from quantrl_lab.environments.stock.strategies.rewards.sharpe import DifferentialSharpeReward
+
+        return DifferentialSharpeReward(risk_free_rate=0.0)
+
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def ppo_class():
+        from stable_baselines3 import PPO
+
+        return PPO
+
+    def ppo_config():
+        return dict(
+            policy='MlpPolicy',
+            ent_coef=0.01,
+            learning_rate=3e-4,
+            n_steps=1024,
+            batch_size=128,
+            gamma=0.98,
+            clip_range=0.1,
+            gae_lambda=0.95,
+            verbose=0,
+        )
+
+    def ppo_reward():
+        from quantrl_lab.environments.stock.strategies.rewards.composite import CompositeReward
+        from quantrl_lab.environments.stock.strategies.rewards.invalid_action import InvalidActionPenalty
+        from quantrl_lab.environments.stock.strategies.rewards.portfolio_value import PortfolioValueChangeReward
+        from quantrl_lab.environments.stock.strategies.rewards.turnover import TurnoverPenaltyReward
+
+        return CompositeReward(
+            strategies=[
+                PortfolioValueChangeReward(),
+                TurnoverPenaltyReward(penalty_factor=0.01),
+                InvalidActionPenalty(penalty=-0.1),
+            ],
+            weights=[1.0, 0.05, 0.5],
+            auto_scale=True,
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def a2c_class():
+        from stable_baselines3 import A2C
+
+        return A2C
+
+    def a2c_config():
+        return dict(
+            policy='MlpPolicy',
+            learning_rate=7e-4,
+            n_steps=5,
+            gamma=0.99,
+            gae_lambda=1.0,
+            ent_coef=0.1,
+            vf_coef=0.5,
+            max_grad_norm=0.5,
+            rms_prop_eps=1e-5,
+            verbose=0,
+        )
+
+    def a2c_reward():
+        from quantrl_lab.environments.stock.strategies.rewards.composite import CompositeReward
+        from quantrl_lab.environments.stock.strategies.rewards.portfolio_value import PortfolioValueChangeReward
+
+        return CompositeReward(
+            strategies=[PortfolioValueChangeReward()],
+            weights=[1.0],
+            auto_scale=False,
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def td3_class():
+        from stable_baselines3 import TD3
+
+        return TD3
+
+    def td3_config():
+        import numpy as np
+        from stable_baselines3.common.noise import NormalActionNoise
+
+        # Action space for StandardActionStrategy is Box(1,) in [-1, 1]
+        action_noise = NormalActionNoise(mean=np.zeros(1), sigma=0.1 * np.ones(1))
+        return dict(
+            policy='MlpPolicy',
+            learning_rate=1e-4,
+            buffer_size=300_000,
+            learning_starts=1_000,
+            batch_size=256,
+            tau=0.005,
+            gamma=0.99,
+            train_freq=1,
+            policy_delay=2,
+            target_policy_noise=0.2,
+            target_noise_clip=0.5,
+            action_noise=action_noise,
+            policy_kwargs=dict(net_arch=[256, 256]),
+            verbose=0,
+        )
+
+    def td3_reward():
+        from quantrl_lab.environments.stock.strategies.rewards.composite import CompositeReward
+        from quantrl_lab.environments.stock.strategies.rewards.portfolio_value import PortfolioValueChangeReward
+        from quantrl_lab.environments.stock.strategies.rewards.turnover import TurnoverPenaltyReward
+
+        return CompositeReward(
+            strategies=[
+                PortfolioValueChangeReward(),
+                TurnoverPenaltyReward(penalty_factor=0.1),
+            ],
+            weights=[1.0, 0.05],
+            auto_scale=False,
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def tqc_class():
+        from sb3_contrib import TQC
+
+        return TQC
+
+    def tqc_config():
+        return dict(
+            policy='MlpPolicy',
+            learning_rate=3e-4,
+            buffer_size=300_000,
+            learning_starts=10_000,
+            batch_size=256,
+            tau=0.005,
+            gamma=0.99,
+            train_freq=1,
+            gradient_steps=1,
+            ent_coef='auto',
+            top_quantiles_to_drop_per_net=1,
+            policy_kwargs=dict(net_arch=[256, 256], n_quantiles=25),
+            verbose=0,
+        )
+
+    def tqc_reward():
+        from quantrl_lab.environments.stock.strategies.rewards.composite import CompositeReward
+        from quantrl_lab.environments.stock.strategies.rewards.invalid_action import InvalidActionPenalty
+        from quantrl_lab.environments.stock.strategies.rewards.portfolio_value import PortfolioValueChangeReward
+        from quantrl_lab.environments.stock.strategies.rewards.turnover import TurnoverPenaltyReward
+
+        return CompositeReward(
+            strategies=[
+                PortfolioValueChangeReward(),
+                TurnoverPenaltyReward(penalty_factor=0.01),
+                InvalidActionPenalty(penalty=-0.1),
+            ],
+            weights=[1.0, 0.05, 0.5],
+            auto_scale=True,
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def trpo_class():
+        from sb3_contrib import TRPO
+
+        return TRPO
+
+    def trpo_config():
+        return dict(
+            policy='MlpPolicy',
+            learning_rate=1e-3,
+            n_steps=2048,
+            batch_size=128,
+            gamma=0.99,
+            gae_lambda=0.95,
+            cg_max_steps=15,
+            target_kl=0.01,
+            ent_coef=0.01,
+            policy_kwargs=dict(net_arch=dict(pi=[128, 128], vf=[128, 128])),
+            verbose=0,
+        )
+
+    def trpo_reward():
+        from quantrl_lab.environments.stock.strategies.rewards.composite import CompositeReward
+        from quantrl_lab.environments.stock.strategies.rewards.drawdown import DrawdownPenaltyReward
+        from quantrl_lab.environments.stock.strategies.rewards.sortino import DifferentialSortinoReward
+        from quantrl_lab.environments.stock.strategies.rewards.turnover import TurnoverPenaltyReward
+
+        return CompositeReward(
+            strategies=[
+                DifferentialSortinoReward(),
+                DrawdownPenaltyReward(penalty_factor=0.5),
+                TurnoverPenaltyReward(penalty_factor=0.1),
+            ],
+            weights=[1.0, 0.2, 0.1],
+            auto_scale=True,
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+
+    def crossq_class():
+        from sb3_contrib import CrossQ
+
+        return CrossQ
+
+    def crossq_config():
+        return dict(
+            policy='MlpPolicy',
+            learning_rate=1e-4,
+            buffer_size=300_000,
+            learning_starts=1_000,
+            batch_size=256,
+            tau=0.005,
+            gamma=0.99,
+            train_freq=1,
+            gradient_steps=1,
+            ent_coef='auto',
+            policy_kwargs=dict(net_arch=[256, 256]),
+            verbose=0,
+        )
+
+    def crossq_reward():
+        from quantrl_lab.environments.stock.strategies.rewards.composite import CompositeReward
+        from quantrl_lab.environments.stock.strategies.rewards.portfolio_value import PortfolioValueChangeReward
+        from quantrl_lab.environments.stock.strategies.rewards.turnover import TurnoverPenaltyReward
+
+        return CompositeReward(
+            strategies=[
+                PortfolioValueChangeReward(),
+                TurnoverPenaltyReward(penalty_factor=0.1),
+            ],
+            weights=[1.0, 0.05],
+            auto_scale=False,
+        )
+
+    # ──────────────────────────────────────────────────────────────────────────
+
+    return {
+        'SAC': AlgorithmPreset(
+            algo_class_factory=sac_class,
+            algorithm_config_factory=sac_config,
+            reward_factory=sac_reward,
+            n_envs=1,
+            description='Off-policy, max-entropy. Best sample efficiency.',
+        ),
+        'PPO': AlgorithmPreset(
+            algo_class_factory=ppo_class,
+            algorithm_config_factory=ppo_config,
+            reward_factory=ppo_reward,
+            n_envs=1,
+            description='On-policy, clipped surrogate. Stable and widely used.',
+        ),
+        'A2C': AlgorithmPreset(
+            algo_class_factory=a2c_class,
+            algorithm_config_factory=a2c_config,
+            reward_factory=a2c_reward,
+            n_envs=4,
+            description='On-policy actor-critic. Fast, lower variance than REINFORCE.',
+        ),
+        'TD3': AlgorithmPreset(
+            algo_class_factory=td3_class,
+            algorithm_config_factory=td3_config,
+            reward_factory=td3_reward,
+            n_envs=1,
+            description='Off-policy, deterministic. Double Q + delayed policy update.',
+        ),
+        'TQC': AlgorithmPreset(
+            algo_class_factory=tqc_class,
+            algorithm_config_factory=tqc_config,
+            reward_factory=tqc_reward,
+            n_envs=1,
+            description='Off-policy, distributional Q. Often outperforms SAC.',
+        ),
+        'TRPO': AlgorithmPreset(
+            algo_class_factory=trpo_class,
+            algorithm_config_factory=trpo_config,
+            reward_factory=trpo_reward,
+            n_envs=4,
+            description='On-policy, trust-region. Monotonic improvement guarantee.',
+        ),
+        'CrossQ': AlgorithmPreset(
+            algo_class_factory=crossq_class,
+            algorithm_config_factory=crossq_config,
+            reward_factory=crossq_reward,
+            n_envs=1,
+            description='Off-policy, batch-norm critic. High sample efficiency.',
+        ),
+    }
+
+
+PRESETS: Dict[str, AlgorithmPreset] = _make_presets()
 
 
 # ── Data ──────────────────────────────────────────────────────────────────────
 
 
-def fetch_sync_enrichment(sources, symbol: str, start_date, end_date) -> dict:
+def build_processed_data(cfg: RunConfig):
     """
-    Synchronously fetch optional FMP + Alpaca enrichment for one symbol.
+    Fetch and process data for a single symbol.
 
-    Returns a dict compatible with ``process_symbol(enrichment=...)``:
-    ``{ratings_df, sector_perf_df, industry_perf_df, news_df}``
+    Returns ``(train_df, test_df)`` ready for the trading environment.
+    Alpha indicator selection is performed explicitly via
+    ``alpha_research`` before the resulting indicator specs are passed
+    into ``DataProcessor``.
     """
-    enrichment = {
-        "ratings_df": None,
-        "sector_perf_df": None,
-        "industry_perf_df": None,
-        "news_df": None,
-    }
+    from quantrl_lab.alpha_research import build_processing_config_from_alpha_selection
+    from quantrl_lab.data.processing import DataProcessor
 
-    if sources.fmp:
-        fmp = sources.fmp
-        try:
-            enrichment["ratings_df"] = fmp.get_historical_rating(symbol, limit=500)
-            console.print(f"[green]Analyst ratings:[/green] {enrichment['ratings_df'].shape}")
-        except Exception as exc:
-            console.print(f"[yellow]Analyst ratings failed: {exc}[/yellow]")
-        try:
-            profile = fmp.get_company_profile(symbol)
-            if not profile.empty:
-                sector = profile.iloc[0].get("sector")
-                industry = profile.iloc[0].get("industry")
-                start_str = start_date.strftime("%Y-%m-%d")
-                end_str = end_date.strftime("%Y-%m-%d")
-                if sector:
-                    enrichment["sector_perf_df"] = fmp.get_historical_sector_performance(
-                        sector, start=start_str, end=end_str
-                    )
-                    console.print(f"[green]Sector perf ({sector}):[/green] {enrichment['sector_perf_df'].shape}")
-                if industry:
-                    enrichment["industry_perf_df"] = fmp.get_historical_industry_performance(
-                        industry, start=start_str, end=end_str
-                    )
-                    console.print(f"[green]Industry perf ({industry}):[/green] {enrichment['industry_perf_df'].shape}")
-        except Exception as exc:
-            console.print(f"[yellow]Market context failed: {exc}[/yellow]")
-
-    if sources.alpaca:
-        try:
-            enrichment["news_df"] = sources.alpaca.get_news_data(symbols=[symbol], start=start_date, end=end_date)
-            console.print(f"[green]News data:[/green] {enrichment['news_df'].shape}")
-        except Exception as exc:
-            console.print(f"[yellow]News data failed: {exc}[/yellow]")
-
-    return enrichment
-
-
-def build_processed_data(symbol: str) -> "pd.DataFrame":  # noqa: F821
-    """
-    Fetch, enrich, and process data for a single symbol.
-
-    Uses shared utilities for data-source init, date range, alpha
-    selection, and pipeline execution.
-    """
-    # 1. Initialise sources and compute date range
     sources = init_data_sources()
-    start_date, end_date = get_date_range(PERIOD_YEARS)
+    start_date, end_date = get_date_range(cfg.period_years)
 
-    # 2. OHLCV
-    raw_df = sources.loader.get_historical_ohlcv_data(symbols=[symbol], start=start_date, end=end_date, timeframe="1d")
-    if "Date" in raw_df.columns:
-        raw_df = raw_df.set_index("Date")
-    console.print(f"[cyan]Raw OHLCV:[/cyan] {raw_df.shape}")
+    raw_df = sources.loader.get_historical_ohlcv_data(
+        symbols=[cfg.symbol], start=start_date, end=end_date, timeframe='1d'
+    )
+    if 'Date' in raw_df.columns:
+        raw_df = raw_df.set_index('Date')
+    console.print(f'[cyan]Raw OHLCV:[/cyan] {raw_df.shape}')
 
-    # 3. Alpha Research — suggest indicators
-    indicators = select_alpha_indicators({symbol: raw_df}, metric="ic", threshold=0.02, top_k=4, verbose=True)
+    processor = DataProcessor(ohlcv_data=raw_df)
+    processing_config, _ = build_processing_config_from_alpha_selection(
+        raw_df,
+        {'metric': 'ic', 'threshold': 0.02, 'top_k': 4},
+        split_config={'train': 0.8, 'test': 0.2},
+        verbose=True,
+    )
+    splits, _ = processor.data_processing_pipeline(
+        pipeline_config=processing_config,
+    )
 
-    # 4. Optional enrichment (sync)
-    enrichment = fetch_sync_enrichment(sources, symbol, start_date, end_date)
-
-    # 5. Build pipeline, execute, drop NaNs (shared utility)
-    processed_df = process_symbol(symbol, raw_df, indicators, enrichment, verbose=True)
-
-    # Drop non-numeric columns that the trading env cannot cast to float32
-    processed_df = processed_df.select_dtypes(include="number")
-    console.print(f"[green]Final shape:[/green] {processed_df.shape}")
-    return processed_df
+    train_df = splits['train'].select_dtypes(include='number')
+    test_df = splits['test'].select_dtypes(include='number')
+    console.print(f'[green]Train:[/green] {train_df.shape}  [green]Test:[/green] {test_df.shape}')
+    console.print(f'[green]Features:[/green] {list(train_df.columns)}')
+    return train_df, test_df
 
 
 # ── Training & Evaluation ─────────────────────────────────────────────────────
 
 
-def main():
-    console.rule(f"[bold blue]Single-Stock Training — {SYMBOL}[/bold blue]")
+def main(cfg: RunConfig = RunConfig()):
+    algo_key = cfg.algo.upper()
+    if algo_key not in PRESETS:
+        console.print(f'[red]Unknown algo "{cfg.algo}". Choose from: {", ".join(PRESETS)}[/red]')
+        return
+
+    preset = PRESETS[algo_key]
+    console.rule(f'[bold blue]Single-Stock {algo_key} Training — {cfg.symbol}[/bold blue]')
+    console.print(f'[dim]{preset.description}[/dim]')
+    overall_start = perf_counter()
 
     # --- Phase 1: Data ---
-    console.rule("[dim]Phase 1: Data[/dim]")
-    processed_df = build_processed_data(SYMBOL)
-    console.print(f"[green]Date range:[/green] {processed_df.index.min().date()} → {processed_df.index.max().date()}")
-    console.print(f"[green]Features:[/green] {list(processed_df.columns)}")
+    console.rule('[dim]Phase 1: Data[/dim]')
+    t0 = perf_counter()
+    train_df, test_df = build_processed_data(cfg)
+    data_sec = perf_counter() - t0
+    console.print(f'[green]Train date range:[/green] {train_df.index.min().date()} → {train_df.index.max().date()}')
+    console.print(f'[green]Test date range:[/green]  {test_df.index.min().date()} → {test_df.index.max().date()}')
+    console.print(f'[dim]Phase 1 duration:[/dim] {data_sec:.2f}s')
 
-    # --- Phase 2: Train/Test split ---
-    console.rule("[dim]Phase 2: Split[/dim]")
-    train_df, test_df = train_test_split_by_date(processed_df, split_ratio=0.8)
-
-    if len(train_df) <= WINDOW_SIZE:
-        console.print(f"[red]Train set too small ({len(train_df)} rows ≤ window_size={WINDOW_SIZE})[/red]")
+    if len(train_df) <= cfg.window_size:
+        console.print(f'[red]Train set too small ({len(train_df)} rows ≤ window_size={cfg.window_size})[/red]')
         return
-    if len(test_df) <= WINDOW_SIZE:
-        console.print(f"[red]Test set too small ({len(test_df)} rows ≤ window_size={WINDOW_SIZE})[/red]")
+    if len(test_df) <= cfg.window_size:
+        console.print(f'[red]Test set too small ({len(test_df)} rows ≤ window_size={cfg.window_size})[/red]')
         return
 
-    # --- Phase 3: Setup Environment using Builder ---
-    console.rule("[dim]Phase 3: Environment[/dim]")
+    # --- Phase 2: Environment ---
+    console.rule('[dim]Phase 2: Environment[/dim]')
+    t0 = perf_counter()
     from quantrl_lab.environments.stock.strategies.actions.standard import StandardActionStrategy
     from quantrl_lab.environments.stock.strategies.observations.feature_aware import FeatureAwareObservationStrategy
-    from quantrl_lab.environments.stock.strategies.rewards.composite import CompositeReward
-    from quantrl_lab.environments.stock.strategies.rewards.drawdown import DrawdownPenaltyReward
-    from quantrl_lab.environments.stock.strategies.rewards.sortino import DifferentialSortinoReward
-    from quantrl_lab.environments.stock.strategies.rewards.turnover import TurnoverPenaltyReward
     from quantrl_lab.experiments.backtesting.builder import BacktestEnvironmentBuilder
-
-    reward_strat = CompositeReward(
-        strategies=[
-            DifferentialSortinoReward(),
-            DrawdownPenaltyReward(penalty_factor=0.5),
-            TurnoverPenaltyReward(penalty_factor=0.5),
-        ],
-        weights=[1.0, 0.2, 0.1],
-        auto_scale=True,
-    )
 
     builder = BacktestEnvironmentBuilder()
     builder.with_data(train_data=train_df, test_data=test_df)
     builder.with_env_params(
         initial_balance=100_000.0,
         transaction_cost_pct=0.001,
-        window_size=WINDOW_SIZE,
+        window_size=cfg.window_size,
+        random_start=True,
     )
     builder.with_strategies(
         action=StandardActionStrategy(),
-        reward=reward_strat,
+        reward=preset.reward_factory(),
         observation=FeatureAwareObservationStrategy(normalize_stationary=True),
     )
     env_config = builder.build()
+    env_sec = perf_counter() - t0
+    console.print(f'[dim]Phase 2 duration:[/dim] {env_sec:.2f}s')
 
-    # --- Phase 4: Run Experiment ---
-    console.rule("[dim]Phase 4: Training[/dim]")
-    from stable_baselines3 import PPO
-
+    # --- Phase 3: Training ---
+    console.rule(f'[dim]Phase 3: Training ({algo_key})[/dim]')
     from quantrl_lab.experiments.backtesting.core import ExperimentJob
     from quantrl_lab.experiments.backtesting.runner import BacktestRunner
 
+    algo_config = preset.algorithm_config_factory()
+    if cfg.algorithm_config:
+        algo_config.update(cfg.algorithm_config)
+
     job = ExperimentJob(
-        algorithm_class=PPO,
+        algorithm_class=preset.algo_class_factory(),
         env_config=env_config,
-        algorithm_config=dict(
-            policy="MlpPolicy",
-            ent_coef=0.01,
-            learning_rate=3e-4,
-            n_steps=2048,
-            batch_size=64,
-        ),
-        total_timesteps=TOTAL_TIMESTEPS,
-        n_envs=1,
+        algorithm_config=algo_config,
+        total_timesteps=cfg.total_timesteps,
+        n_envs=preset.n_envs,
     )
 
     runner = BacktestRunner(verbose=True)
     result = runner.run_job(job)
-    runner.inspect_result(result)
+
+    # --- Phase 4: Results ---
+    console.rule('[dim]Phase 4: Results[/dim]')
+    from quantrl_lab.experiments.benchmarks import BenchmarkComparison
+
+    # Detect the close price column (handles 'close', 'Close', 'adj_close', etc.)
+    close_col = next((c for c in test_df.columns if c.lower() in ('close', 'adj_close')), test_df.columns[3])
+    benchmarks = BenchmarkComparison(
+        result,
+        index_symbol=cfg.symbol,
+        index_start=test_df.index.min().strftime('%Y-%m-%d'),
+        index_end=test_df.index.max().strftime('%Y-%m-%d'),
+        price_series=test_df[close_col],
+    )
+    runner.inspect_result(result, benchmarks=benchmarks)
+
+    total_sec = perf_counter() - overall_start
+    phase_table = Table(title='Script Runtime Summary', show_header=True, header_style='bold green')
+    phase_table.add_column('Phase', style='cyan')
+    phase_table.add_column('Duration (s)', justify='right')
+    phase_table.add_row('1. Data', f'{data_sec:.2f}')
+    phase_table.add_row('2. Environment', f'{env_sec:.2f}')
+    phase_table.add_row('3. Training + Eval', f'{result.execution_time:.2f}')
+    phase_table.add_row('[bold]Total[/bold]', f'[bold]{total_sec:.2f}[/bold]')
+    console.print(phase_table)
 
 
-if __name__ == "__main__":
-    main()
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Single-stock RL training')
+    parser.add_argument(
+        '--algo',
+        type=str,
+        default=RunConfig.algo,
+        choices=list(PRESETS),
+        help='Algorithm to use (default: %(default)s)',
+    )
+    parser.add_argument('--symbol', type=str, default=RunConfig.symbol)
+    parser.add_argument('--period-years', type=int, default=RunConfig.period_years)
+    parser.add_argument('--window-size', type=int, default=RunConfig.window_size)
+    parser.add_argument('--total-timesteps', type=int, default=RunConfig.total_timesteps)
+    parser.add_argument(
+        '--algorithm-config',
+        type=str,
+        default=None,
+        metavar='JSON',
+        help='JSON string of hyperparameter overrides, e.g. \'{"learning_rate": 1e-3}\'',
+    )
+    args = parser.parse_args()
+
+    algo_config_override = json.loads(args.algorithm_config) if args.algorithm_config else None
+
+    main(
+        RunConfig(
+            algo=args.algo,
+            symbol=args.symbol,
+            period_years=args.period_years,
+            window_size=args.window_size,
+            total_timesteps=args.total_timesteps,
+            algorithm_config=algo_config_override,
+        )
+    )

--- a/examples/end_to_end/single_asset/tune_single_symbol.py
+++ b/examples/end_to_end/single_asset/tune_single_symbol.py
@@ -3,12 +3,10 @@ Single-stock hyperparameter tuning script.
 
 Validates the full workflow end-to-end on a single symbol with Optuna:
   1. Fetch OHLCV data
-  2. Alpha Research — suggest indicators
-  3. Fetch optional enrichment data (FMP, Alpaca)
-  4. Build and execute the DataPipeline (via shared utilities)
-  5. Train/eval/test split (3-way)
-  6. Tune PPO hyperparameters using Optuna (optimizing on the eval set)
-  7. Report best hyperparameters
+  2. DataProcessor runs alpha selection and builds the full feature pipeline
+  3. Train/eval/test split (3-way, inline)
+  4. Tune PPO hyperparameters using Optuna (optimizing on the eval set)
+  5. Report best hyperparameters
 """
 
 import os
@@ -28,9 +26,6 @@ console = Console()
 from shared.data_utils import (  # noqa: E402
     get_date_range,
     init_data_sources,
-    process_symbol,
-    select_alpha_indicators,
-    train_eval_test_split_by_date,
 )
 
 SYMBOL = "AAPL"
@@ -95,31 +90,47 @@ def fetch_sync_enrichment(sources, symbol: str, start_date, end_date) -> dict:
     return enrichment
 
 
-def build_processed_data(symbol: str) -> "pd.DataFrame":  # noqa: F821
-    """Fetch, enrich, and process data for a single symbol."""
-    # 1. Initialise sources and compute date range
+def build_processed_data(symbol: str):
+    """
+    Fetch and process data for a single symbol.
+
+    Returns ``(train_df, eval_df, test_df)`` ready for tuning.
+    Alpha indicator selection is performed explicitly via
+    ``alpha_research`` before the resulting indicator specs are passed
+    into ``DataProcessor``.
+    """
+    from quantrl_lab.alpha_research import build_processing_config_from_alpha_selection
+    from quantrl_lab.data.processing import DataProcessor
+
     sources = init_data_sources()
     start_date, end_date = get_date_range(PERIOD_YEARS)
 
-    # 2. OHLCV
     raw_df = sources.loader.get_historical_ohlcv_data(symbols=[symbol], start=start_date, end=end_date, timeframe="1d")
     if "Date" in raw_df.columns:
         raw_df = raw_df.set_index("Date")
     console.print(f"[cyan]Raw OHLCV:[/cyan] {raw_df.shape}")
 
-    # 3. Alpha Research — suggest indicators
-    indicators = select_alpha_indicators({symbol: raw_df}, metric="ic", threshold=0.02, top_k=4, verbose=True)
+    processor = DataProcessor(ohlcv_data=raw_df)
+    processing_config, _ = build_processing_config_from_alpha_selection(
+        raw_df,
+        {"metric": "ic", "threshold": 0.02, "top_k": 4},
+        split_config={"train": 0.70, "eval": 0.15, "test": 0.15},
+        verbose=True,
+    )
+    splits, metadata = processor.data_processing_pipeline(
+        pipeline_config=processing_config,
+    )
 
-    # 4. Optional enrichment (sync)
-    enrichment = fetch_sync_enrichment(sources, symbol, start_date, end_date)
-
-    # 5. Build pipeline, execute, drop NaNs
-    processed_df = process_symbol(symbol, raw_df, indicators, enrichment, verbose=True)
-
-    # Drop non-numeric columns that the trading env cannot cast to float32
-    processed_df = processed_df.select_dtypes(include="number")
-    console.print(f"[green]Final shape:[/green] {processed_df.shape}")
-    return processed_df
+    train_df = splits["train"].select_dtypes(include="number")
+    eval_df = splits["eval"].select_dtypes(include="number")
+    test_df = splits["test"].select_dtypes(include="number")
+    console.print(
+        f"[green]Train:[/green] {train_df.shape}  "
+        f"[green]Eval:[/green] {eval_df.shape}  "
+        f"[green]Test:[/green] {test_df.shape}"
+    )
+    console.print(f"[green]Features:[/green] {list(train_df.columns)}")
+    return train_df, eval_df, test_df
 
 
 # ── Tuning ────────────────────────────────────────────────────────────────────
@@ -128,15 +139,11 @@ def build_processed_data(symbol: str) -> "pd.DataFrame":  # noqa: F821
 def main():
     console.rule(f"[bold blue]Single-Stock Tuning — {SYMBOL}[/bold blue]")
 
-    # --- Phase 1: Data ---
+    # --- Phase 1: Data (fetch + alpha selection + 3-way split) ---
     console.rule("[dim]Phase 1: Data[/dim]")
-    processed_df = build_processed_data(SYMBOL)
-    console.print(f"[green]Date range:[/green] {processed_df.index.min().date()} → {processed_df.index.max().date()}")
-    console.print(f"[green]Features:[/green] {list(processed_df.columns)}")
-
-    # --- Phase 2: Train/Eval/Test split ---
-    console.rule("[dim]Phase 2: Split[/dim]")
-    train_df, eval_df, test_df = train_eval_test_split_by_date(processed_df, train_ratio=0.7, eval_ratio=0.15)
+    train_df, eval_df, test_df = build_processed_data(SYMBOL)
+    console.print(f"[green]Train date range:[/green] {train_df.index.min().date()} → {train_df.index.max().date()}")
+    console.print(f"[green]Test date range:[/green]  {test_df.index.min().date()} → {test_df.index.max().date()}")
 
     if len(train_df) <= WINDOW_SIZE:
         console.print(f"[red]Train set too small ({len(train_df)} rows <= window_size={WINDOW_SIZE})[/red]")
@@ -148,8 +155,8 @@ def main():
         console.print(f"[red]Test set too small ({len(test_df)} rows <= window_size={WINDOW_SIZE})[/red]")
         return
 
-    # --- Phase 3: Setup Environment using Builder ---
-    console.rule("[dim]Phase 3: Environment[/dim]")
+    # --- Phase 2: Setup Environment using Builder ---
+    console.rule("[dim]Phase 2: Environment[/dim]")
     from quantrl_lab.environments.stock.strategies.actions.standard import StandardActionStrategy
     from quantrl_lab.environments.stock.strategies.observations.feature_aware import FeatureAwareObservationStrategy
     from quantrl_lab.environments.stock.strategies.rewards.composite import CompositeReward
@@ -184,8 +191,8 @@ def main():
     )
     env_config = builder.build()
 
-    # --- Phase 4: Run Tuning Experiment ---
-    console.rule("[dim]Phase 4: Hyperparameter Tuning[/dim]")
+    # --- Phase 3: Run Tuning Experiment ---
+    console.rule("[dim]Phase 3: Hyperparameter Tuning[/dim]")
     from stable_baselines3 import PPO
 
     from quantrl_lab.experiments.backtesting.core import ExperimentJob
@@ -224,8 +231,8 @@ def main():
     for key, value in study.best_params.items():
         console.print(f"  [yellow]{key}[/yellow]: {value}")
 
-    # --- Phase 5: Refit on train+eval, evaluate on test ---
-    console.rule("[dim]Phase 5: Refit & Final Evaluation[/dim]")
+    # --- Phase 4: Refit on train+eval, evaluate on test ---
+    console.rule("[dim]Phase 4: Refit & Final Evaluation[/dim]")
 
     import pandas as pd
 

--- a/examples/features/indicator_selection_workflow.py
+++ b/examples/features/indicator_selection_workflow.py
@@ -51,7 +51,10 @@ def main():
     # We test a default grid of RSI, MACD, SMA, BB, etc.
     console.print("Testing candidate indicators...")
     best_indicators = selector.suggest_indicators(
-        metric="sharpe_ratio", threshold=0.0, top_k=3  # Only keep positive Sharpe  # Top 3
+        metric="sharpe_ratio",
+        threshold=0.0,
+        top_k=3,
+        selection_mode="strategy",
     )
 
     if not best_indicators:

--- a/examples/pipelines/alpha_to_features_pipeline.py
+++ b/examples/pipelines/alpha_to_features_pipeline.py
@@ -1,0 +1,295 @@
+"""
+Integration example: Alpha Research → Feature Pipeline.
+
+Covers the full chain from raw OHLCV data to clean, split DataFrames that
+are ready to hand off to BacktestRunner / ExperimentJob:
+
+  1. Synthetic OHLCV data (no API keys needed)
+  2. AlphaSelector.suggest_indicators()  — discover alpha-carrying indicators
+  3. converters.results_to_pipeline_config() — convert results → indicator specs
+  4. DataProcessor.data_processing_pipeline()
+       • indicators from alpha research
+       • ratio-based 70/15/15 train/val/test split
+       • ProcessingMetadata inspection
+  5. Per-split summary table — shapes, date ranges, feature count
+  6. Column listing confirming readiness for RL experiments
+
+Run with:
+    uv run python examples/pipelines/alpha_to_features_pipeline.py
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+from rich.console import Console
+from rich.table import Table
+
+from quantrl_lab.alpha_research import INDICATOR_STRATEGY_MAP
+from quantrl_lab.alpha_research.converters import results_to_pipeline_config
+from quantrl_lab.alpha_research.models import AlphaJob
+from quantrl_lab.alpha_research.runner import AlphaRunner
+from quantrl_lab.alpha_research.selector import AlphaSelector
+from quantrl_lab.data.processing import DataProcessor
+
+console = Console()
+
+
+# ── Synthetic data ──────────────────────────────────────────────────────────
+
+
+def make_ohlcv(n: int = 756, seed: int = 42) -> pd.DataFrame:
+    """Three years of synthetic daily OHLCV (no API key needed)."""
+    np.random.seed(seed)
+    log_returns = np.random.randn(n) * 0.012 + 0.0003  # slight upward drift
+    close = 100.0 * np.exp(np.cumsum(log_returns))
+    noise = np.random.randn(n)
+    return pd.DataFrame(
+        {
+            'Open': close * (1 + noise * 0.002),
+            'High': close * (1 + np.abs(noise) * 0.006 + 0.002),
+            'Low': close * (1 - np.abs(noise) * 0.006 - 0.002),
+            'Close': close,
+            'Volume': np.random.randint(1_000_000, 10_000_000, n),
+        },
+        index=pd.date_range('2021-01-04', periods=n, freq='B'),
+    )
+
+
+# ── Step 1 — Data ────────────────────────────────────────────────────────────
+
+
+def step1_load_data() -> pd.DataFrame:
+    console.rule('[bold cyan]Step 1 · Synthetic OHLCV data[/bold cyan]')
+    data = make_ohlcv()
+    console.print(
+        f'  Rows: {len(data)}  |  '
+        f'Date range: {data.index[0].date()} → {data.index[-1].date()}  |  '
+        f'Columns: {list(data.columns)}'
+    )
+    return data
+
+
+# ── Step 2 — Alpha Research ──────────────────────────────────────────────────
+
+
+# Candidate indicators to screen (fast subset — runs in seconds)
+CANDIDATES = [
+    {'name': 'RSI', 'params': {'window': 14}},
+    {'name': 'RSI', 'params': {'window': 21}},
+    {'name': 'SMA', 'params': {'window': 20}},
+    {'name': 'SMA', 'params': {'window': 50}},
+    {'name': 'EMA', 'params': {'window': 12}},
+    {'name': 'EMA', 'params': {'window': 26}},
+    {'name': 'MACD', 'params': {'fast': 12, 'slow': 26, 'signal': 9}},
+    {'name': 'ATR', 'params': {'window': 14}},
+    {'name': 'BB', 'params': {'window': 20}},
+]
+
+
+def step2_alpha_research(data: pd.DataFrame):
+    """Run AlphaSelector to rank candidate indicators by feature-mode
+    IC."""
+    console.rule('[bold cyan]Step 2 · AlphaSelector — indicator ranking[/bold cyan]')
+
+    selector = AlphaSelector(data, verbose=False)
+
+    # suggest_indicators returns indicator specs sorted by `metric`
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        selected_specs = selector.suggest_indicators(
+            candidates=CANDIDATES,
+            metric='ic',
+            threshold=0.0,  # keep all — we'll filter via top_n in step 3
+            top_k=len(CANDIDATES),
+            selection_mode='feature',
+        )
+
+    console.print(f'  Candidates evaluated: {len(CANDIDATES)}')
+    console.print(f'  Specs returned by suggest_indicators: {len(selected_specs)}')
+    for spec in selected_specs:
+        console.print(f'    {spec}')
+
+    # Also collect the underlying AlphaResult objects for results_to_pipeline_config
+    runner = AlphaRunner(verbose=False)
+    jobs = []
+    for cand in CANDIDATES:
+        strategy_config = INDICATOR_STRATEGY_MAP.get(cand['name'])
+        if strategy_config is None:
+            continue
+        jobs.append(
+            AlphaJob(
+                data=data,
+                indicator_name=cand['name'],
+                indicator_params=cand['params'],
+                strategy_name=strategy_config['name'],
+                strategy_params=strategy_config.get('params', {}),
+            )
+        )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        results = runner.run_batch(jobs, n_jobs=1)
+
+    completed = [r for r in results if r.status == 'completed']
+    console.print(f'\n  AlphaRunner: {len(jobs)} jobs → {len(completed)} completed')
+
+    # Print IC ranking table
+    table = Table(title='IC ranking (all candidates)')
+    table.add_column('Indicator', style='magenta')
+    table.add_column('Params')
+    table.add_column('IC', justify='right')
+    table.add_column('Sharpe', justify='right')
+
+    for r in sorted(completed, key=lambda x: x.metrics.get('ic', 0), reverse=True):
+        table.add_row(
+            r.job.indicator_name,
+            str(r.job.indicator_params),
+            f"{r.metrics.get('ic', 0):.4f}",
+            f"{r.metrics.get('sharpe_ratio', 0):.2f}",
+        )
+    console.print(table)
+
+    return completed
+
+
+# ── Step 3 — Convert Results → Pipeline Config ───────────────────────────────
+
+
+def step3_build_indicator_specs(completed_results):
+    """Convert AlphaResult list → deduplicated indicator specs for
+    DataProcessor."""
+    console.rule('[bold cyan]Step 3 · results_to_pipeline_config()[/bold cyan]')
+
+    # top_n=5, best param per indicator name, ranked by IC
+    indicator_specs = results_to_pipeline_config(
+        completed_results,
+        top_n=5,
+        metric='ic',
+        deduplicate=True,
+    )
+
+    console.print(f'  Selected {len(indicator_specs)} indicators (top-5, deduplicated by name):')
+    for spec in indicator_specs:
+        console.print(f'    {spec}')
+
+    return indicator_specs
+
+
+# ── Step 4 — DataProcessor Pipeline ─────────────────────────────────────────
+
+
+def step4_process_and_split(data: pd.DataFrame, indicator_specs):
+    """Run DataProcessor with the selected indicators and a 70/15/15
+    split."""
+    console.rule('[bold cyan]Step 4 · DataProcessor.data_processing_pipeline()[/bold cyan]')
+
+    processor = DataProcessor(ohlcv_data=data)
+
+    # Ratio-based train / val / test split
+    split_config = {'train': 0.70, 'val': 0.15, 'test': 0.15}
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        splits, metadata = processor.data_processing_pipeline(
+            indicators=indicator_specs,
+            split_config=split_config,
+        )
+
+    console.print(f'  Split config: {split_config}')
+    return splits, metadata
+
+
+# ── Step 5 — Metadata Inspection ─────────────────────────────────────────────
+
+
+def step5_inspect_metadata(metadata: dict):
+    """Print the ProcessingMetadata returned by the pipeline."""
+    console.rule('[bold cyan]Step 5 · ProcessingMetadata[/bold cyan]')
+
+    table = Table(title='Processing metadata')
+    table.add_column('Key', style='magenta')
+    table.add_column('Value')
+
+    for key, value in metadata.items():
+        if isinstance(value, dict):
+            for sub_key, sub_value in value.items():
+                table.add_row(f'{key}.{sub_key}', str(sub_value))
+        else:
+            table.add_row(key, str(value))
+
+    console.print(table)
+
+
+# ── Step 6 — Split Summary ───────────────────────────────────────────────────
+
+
+def step6_split_summary(splits: dict):
+    """Print shape, date range, and feature columns for each split."""
+    console.rule('[bold cyan]Step 6 · Per-split summary[/bold cyan]')
+
+    summary_table = Table(title='Train / Val / Test split summary')
+    summary_table.add_column('Split', style='magenta')
+    summary_table.add_column('Rows', justify='right')
+    summary_table.add_column('Cols', justify='right')
+
+    for split_name, df in splits.items():
+        summary_table.add_row(split_name, str(len(df)), str(df.shape[1]))
+
+    console.print(summary_table)
+
+    # Feature columns (same across all splits)
+    first_split = next(iter(splits.values()))
+    feature_cols = list(first_split.columns)
+
+    # Categorise by prefix
+    ohlcv_cols = [c for c in feature_cols if c in ('Open', 'High', 'Low', 'Close', 'Volume')]
+    indicator_cols = [c for c in feature_cols if c not in ohlcv_cols]
+
+    console.print(f'\n  OHLCV columns   ({len(ohlcv_cols)}): {ohlcv_cols}')
+    console.print(f'  Indicator cols  ({len(indicator_cols)}): {indicator_cols}')
+    console.print(f'  Total features  : {len(feature_cols)}')
+
+    console.print(
+        '\n[dim]These DataFrames are ready to pass directly to '
+        'BacktestRunner via BacktestEnvironmentBuilder.with_data(train_data=..., test_data=...).[/dim]'
+    )
+
+    return splits
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+
+def main():
+    console.print(
+        '\n[bold]Alpha Research → Feature Pipeline Integration Example[/bold]\n'
+        '[dim]No API keys required — all data is synthetic.[/dim]\n'
+    )
+
+    # 1. Raw data
+    data = step1_load_data()
+
+    # 2. Alpha research — rank indicators by IC
+    completed_results = step2_alpha_research(data)
+
+    # 3. Convert results to indicator specs
+    if not completed_results:
+        console.print('[red]No completed alpha results — cannot continue.[/red]')
+        return
+    indicator_specs = step3_build_indicator_specs(completed_results)
+
+    # 4. DataProcessor: apply indicators + split
+    splits, metadata = step4_process_and_split(data, indicator_specs)
+
+    # 5. Inspect metadata
+    step5_inspect_metadata(metadata)
+
+    # 6. Per-split summary
+    step6_split_summary(splits)
+
+    console.print('\n[green]Integration pipeline complete.[/green]')
+
+
+if __name__ == '__main__':
+    main()

--- a/notebooks/data_joining_tutorial.ipynb
+++ b/notebooks/data_joining_tutorial.ipynb
@@ -17,6 +17,7 @@
     "\n",
     "from datetime import datetime, timedelta\n",
     "from quantrl_lab.data import DataProcessor\n",
+    "from quantrl_lab.data.processing import ProcessingPipelineConfig, SplitConfig\n",
     "from quantrl_lab.data.source_registry import DataSourceRegistry\n",
     "from quantrl_lab.data.processing.sentiment import HuggingFaceConfig, HuggingFaceProvider, SentimentConfig"
    ]
@@ -756,12 +757,16 @@
     }
    ],
    "source": [
-    "split_data, metadata = processor.data_processing_pipeline(\n",
+    "pipeline_config = ProcessingPipelineConfig(\n",
     "        indicators=indicators,\n",
-    "        fillna_strategy=\"exponential_decay\", \n",
-    "        split_config=split_config,\n",
+    "        fillna_strategy=\"exponential_decay\",\n",
+    "        split=SplitConfig(splits=split_config),\n",
     "        verbose=False,\n",
-    "        decay_rate=0.8  # Configurable\n",
+    "    )\n",
+    "\n",
+    "# The high-level pipeline uses the built-in default decay_rate=0.8 for exponential decay.\n",
+    "split_data, metadata = processor.data_processing_pipeline(\n",
+    "        pipeline_config=pipeline_config,\n",
     "    )"
    ]
   },

--- a/src/quantrl_lab/alpha_research/README.md
+++ b/src/quantrl_lab/alpha_research/README.md
@@ -8,14 +8,19 @@ This module is designed to answer the question: *"Does this indicator have predi
 
 It decouples the signal discovery process from the full event-driven RL backtesting engine, allowing you to screen hundreds of potential features quickly. Validated signals can then be automatically converted into configuration for the `DataPipeline`.
 
+Alpha selection supports two explicit modes:
+
+- `selection_mode="feature"` ranks indicators by continuous score predictive power (`ic`, `rank_ic`, `mutual_info`).
+- `selection_mode="strategy"` ranks indicators by discrete trading-rule behavior and backtest metrics (`sharpe_ratio`, `annual_return`, `ic`, etc.).
+
 ## Module Structure
 
 The module is organized into the following components:
 
 ### Core Components
 - **`models.py`**: Defines the core data structures:
-    - `AlphaJob`: Configuration for a single research task (data, indicator, strategy parameters).
-    - `AlphaResult`: The output of a job, containing performance metrics, equity curves, and signal data. The `error` field stores a traceback string (not an `Exception`) so results are safely picklable across `joblib` parallel workers.
+    - `AlphaJob`: Configuration for a single research task (data, indicator, strategy parameters, and evaluation mode).
+    - `AlphaResult`: The output of a job, containing performance metrics plus equity curves/signals for strategy mode or continuous scores for feature mode. The `error` field stores a traceback string (not an `Exception`) so results are safely picklable across `joblib` parallel workers.
 - **`runner.py`**: Contains `AlphaRunner`, the execution engine that processes `AlphaJob`s (sequentially or in parallel) and calculates performance metrics. OHLCV columns are automatically normalised to title-case (`close` → `Close`) so data from lowercase sources is accepted without pre-processing.
 - **`alpha_strategies.py`**: Implements vectorized trading logic (e.g., `MeanReversionStrategy`, `TrendFollowingStrategy`) used to translate raw indicator values into buy/sell signals for testing.
 
@@ -25,6 +30,8 @@ The module is organized into the following components:
 - **`visualization.py`**: Contains `AlphaVisualizer` for generating professional-grade charts (Cumulative Returns, Drawdowns, IC Analysis) and HTML reports.
 
 ### Utilities
+- **`indicator_research.py`**: Explicit research metadata for each built-in indicator, including default candidate grids, strategy wiring, and supported selection modes.
+- **`integration.py`**: Adapters for converting alpha-selection output into `ProcessingPipelineConfig` objects for the data-processing layer.
 - **`converters.py`**: Utilities to bridge the gap between this module and the rest of the system. Specifically, `results_to_pipeline_config` converts successful `AlphaResult` objects into a `DataPipeline` configuration.
 - **`metrics.py`**: Signal quality functions: IC (Pearson), Rank IC (Spearman), autocorrelation, and turnover.
 - **`registry.py`**: A registry system for managing available vectorized strategies.
@@ -72,6 +79,14 @@ for res in results:
         print(f"{res.job.indicator_name}: FAILED\n{res.error}")
 ```
 
+For feature-screening instead of backtest metrics, set `evaluation_mode="feature"` on each `AlphaJob`.
+
+Strategy-mode and feature-mode results are both valid `AlphaResult`s, but not every downstream tool consumes both:
+
+- `AlphaEnsemble` expects strategy-mode results with equity curves.
+- cumulative-return and drawdown plots in `AlphaVisualizer` also expect strategy-mode results.
+- IC-style ranking and pipeline configuration conversion work with either mode, as long as the selected metric exists.
+
 ### 2. Robustness Testing
 
 Use the explicit `indicator_param_grid` / `strategy_param_grid` split to ensure parameters are always routed to the correct `AlphaJob` dict. The legacy flat `param_grid` is still accepted for backward compatibility but can mis-route new indicator params.
@@ -105,22 +120,25 @@ viz.generate_html_report(results, "alpha_report.html")
 ### 4. Integration with DataPipeline
 
 ```python
-from quantrl_lab.alpha_research.converters import results_to_pipeline_config
-from quantrl_lab.data.processing.pipeline import DataPipeline
-from quantrl_lab.data.processing.steps import TechnicalIndicatorStep
+from quantrl_lab.alpha_research import build_processing_config_from_alpha_selection
+from quantrl_lab.data.processing import DataProcessor
 
-# Select top 5 indicators by IC.
-# Use deduplicate=True when the same indicator was tested with multiple parameter
-# sets — keeps only the best-scoring result per indicator name.
-pipeline_config = results_to_pipeline_config(results, top_n=5, metric="ic", deduplicate=True)
+# Build a ready-to-run processing config using train-only alpha selection
+processing_config, selection_meta = build_processing_config_from_alpha_selection(
+    raw_data=data,
+    alpha_selection_config={"metric": "ic", "threshold": 0.02, "top_k": 5, "selection_mode": "feature"},
+    split_config={"train": 0.7, "test": 0.3},
+)
 
-# Configure the pipeline
-pipeline = DataPipeline()
-pipeline.add_step(TechnicalIndicatorStep(indicators=pipeline_config))
-
-# Process data for RL training
-processed_data, _ = pipeline.execute(data)
+# Execute the processing plan
+processor = DataProcessor(ohlcv_data=data)
+processed_data, metadata = processor.data_processing_pipeline(
+    pipeline_config=processing_config
+)
 ```
+
+If you already have `AlphaResult` objects and just want indicator specs, `results_to_pipeline_config(...)`
+still converts them into the `indicators=[...]` format expected by `DataProcessor`.
 
 ### 5. Williams %R / Custom Indicator Scales
 

--- a/src/quantrl_lab/alpha_research/__init__.py
+++ b/src/quantrl_lab/alpha_research/__init__.py
@@ -2,18 +2,33 @@ from .alpha_strategies import (
     ADXTrendStrategy,
     BollingerBandsStrategy,
     CCIStrategy,
+    ChannelBreakoutStrategy,
+    CrossoverStrategy,
+    FlowTrendStrategy,
     MACDCrossoverStrategy,
     MeanReversionStrategy,
     OnBalanceVolumeStrategy,
     StochasticStrategy,
     TrendFollowingStrategy,
     VolatilityBreakoutStrategy,
+    ZeroLineStrategy,
 )
 from .analysis import RobustnessTester
 from .base import SignalType, VectorizedTradingStrategy
 from .ensemble import AlphaEnsemble
+from .indicator_research import (
+    FEATURE_SELECTION_MODE,
+    INDICATOR_RESEARCH_METADATA,
+    INDICATOR_STRATEGY_MAP,
+    STRATEGY_SELECTION_MODE,
+)
+from .integration import (
+    AlphaSelectionConfig,
+    build_processing_config_from_alpha_selection,
+    select_indicators_for_processing,
+)
 from .models import AlphaJob, AlphaResult
-from .registry import VectorizedStrategyRegistry
+from .registry import StrategyMetadata, VectorizedStrategyRegistry
 from .runner import AlphaRunner
 from .selector import AlphaSelector
 from .visualization import AlphaVisualizer
@@ -24,18 +39,30 @@ __all__ = [
     "TrendFollowingStrategy",
     "MeanReversionStrategy",
     "MACDCrossoverStrategy",
+    "CrossoverStrategy",
     "VolatilityBreakoutStrategy",
     "BollingerBandsStrategy",
     "StochasticStrategy",
+    "ZeroLineStrategy",
+    "FlowTrendStrategy",
     "OnBalanceVolumeStrategy",
+    "ChannelBreakoutStrategy",
     "ADXTrendStrategy",
     "CCIStrategy",
     "AlphaEnsemble",
     "AlphaJob",
     "AlphaResult",
     "AlphaRunner",
+    "AlphaSelectionConfig",
     "VectorizedStrategyRegistry",
+    "StrategyMetadata",
     "RobustnessTester",
     "AlphaSelector",
     "AlphaVisualizer",
+    "FEATURE_SELECTION_MODE",
+    "INDICATOR_STRATEGY_MAP",
+    "INDICATOR_RESEARCH_METADATA",
+    "STRATEGY_SELECTION_MODE",
+    "build_processing_config_from_alpha_selection",
+    "select_indicators_for_processing",
 ]

--- a/src/quantrl_lab/alpha_research/alpha_strategies.py
+++ b/src/quantrl_lab/alpha_research/alpha_strategies.py
@@ -1,11 +1,14 @@
+from typing import Any, Dict, List
+
 import numpy as np
 import pandas as pd
 
 from .base import SignalType, VectorizedTradingStrategy
+from .indicator_research import INDICATOR_STRATEGY_MAP  # noqa: F401
 from .registry import VectorizedStrategyRegistry
 
 
-@VectorizedStrategyRegistry.register("trend_following")
+@VectorizedStrategyRegistry.register("trend_following", description="Buy when price > indicator, sell when below")
 class TrendFollowingStrategy(VectorizedTradingStrategy):
     """Strategy for trend-following indicators like SMA, EMA."""
 
@@ -67,8 +70,24 @@ class TrendFollowingStrategy(VectorizedTradingStrategy):
         """
         return [self.indicator_col, "Close"]
 
+    @classmethod
+    def resolve_columns(cls, new_cols: List[str], current_params: Dict[str, Any]) -> Dict[str, Any]:
+        """Prefer line-like outputs over direction/helper columns."""
+        if "indicator_col" in current_params or not new_cols:
+            return {}
 
-@VectorizedStrategyRegistry.register("mean_reversion")
+        preferred = [
+            c
+            for c in new_cols
+            if all(token not in c.lower() for token in ["dir", "signal", "hist", "upper", "lower", "middle"])
+        ]
+        chosen = preferred[0] if preferred else new_cols[0]
+        return {"indicator_col": chosen}
+
+
+@VectorizedStrategyRegistry.register(
+    "mean_reversion", description="Buy when oversold, sell when overbought (RSI, MFI, Williams %R)"
+)
 class MeanReversionStrategy(VectorizedTradingStrategy):
     """Strategy for mean-reversion indicators like RSI, MFI, Williams
     %R."""
@@ -158,7 +177,7 @@ class MeanReversionStrategy(VectorizedTradingStrategy):
         return [self.indicator_col]
 
 
-@VectorizedStrategyRegistry.register("macd_crossover")
+@VectorizedStrategyRegistry.register("macd_crossover", description="Buy when MACD line crosses above signal line")
 class MACDCrossoverStrategy(VectorizedTradingStrategy):
     """Strategy for crossover indicators from MACD line."""
 
@@ -211,6 +230,21 @@ class MACDCrossoverStrategy(VectorizedTradingStrategy):
 
         return scores.clip(-1.0, 1.0)
 
+    @classmethod
+    def resolve_columns(cls, new_cols: List[str], current_params: Dict[str, Any]) -> Dict[str, Any]:
+        """Wire MACD line → fast_col, signal line → slow_col."""
+
+        def _find(substring: str) -> Any:
+            matches = [c for c in new_cols if substring in c]
+            return matches[0] if matches else None
+
+        resolved: Dict[str, Any] = {}
+        if "fast_col" not in current_params:
+            resolved["fast_col"] = _find("MACD_line")
+        if "slow_col" not in current_params:
+            resolved["slow_col"] = _find("MACD_signal")
+        return resolved
+
     def get_required_columns(self) -> list:
         """
         Get the list of required columns for the strategy.
@@ -221,7 +255,145 @@ class MACDCrossoverStrategy(VectorizedTradingStrategy):
         return [self.fast_col, self.slow_col, "Close"]
 
 
-@VectorizedStrategyRegistry.register("volatility_breakout")
+@VectorizedStrategyRegistry.register("crossover", description="Buy when fast line crosses above slow line")
+class CrossoverStrategy(VectorizedTradingStrategy):
+    """Generic crossover strategy for paired indicator lines."""
+
+    def __init__(
+        self,
+        fast_col: str,
+        slow_col: str,
+        allow_short: bool = True,
+        score_normalization: str = "zscore",
+    ):
+        self.fast_col = fast_col
+        self.slow_col = slow_col
+        self.allow_short = allow_short
+        self.score_normalization = score_normalization
+
+    def generate_signals(self, data: pd.DataFrame) -> pd.Series:
+        """Generate crossover signals from fast and slow indicator
+        lines."""
+        signals = pd.Series(SignalType.HOLD.value, index=data.index)
+
+        if self.fast_col not in data.columns or self.slow_col not in data.columns:
+            return signals
+
+        signals[data[self.fast_col] > data[self.slow_col]] = SignalType.BUY.value
+        if self.allow_short:
+            signals[data[self.fast_col] < data[self.slow_col]] = SignalType.SELL.value
+
+        return signals
+
+    def generate_scores(self, data: pd.DataFrame) -> pd.Series:
+        """Generate continuous crossover strength scores."""
+        if self.fast_col not in data.columns or self.slow_col not in data.columns:
+            return pd.Series(0.0, index=data.index)
+
+        spread = data[self.fast_col] - data[self.slow_col]
+
+        if self.score_normalization == "close_pct":
+            close = data["Close"].replace(0, np.nan)
+            scores = (spread / close) * 100.0
+            return scores.clip(-1.0, 1.0).fillna(0.0)
+
+        return self._rolling_zscore(spread, window=60).fillna(0.0)
+
+    @classmethod
+    def resolve_columns(cls, new_cols: List[str], current_params: Dict[str, Any]) -> Dict[str, Any]:
+        """Resolve fast and slow columns from generic crossover
+        outputs."""
+        resolved: Dict[str, Any] = {}
+        signal_cols = [c for c in new_cols if "signal" in c.lower()]
+        line_cols = [
+            c for c in new_cols if "signal" not in c.lower() and "hist" not in c.lower() and "dir" not in c.lower()
+        ]
+        positive_cols = [c for c in new_cols if any(token in c.lower() for token in ["_pos", "_up"])]
+        negative_cols = [c for c in new_cols if any(token in c.lower() for token in ["_neg", "_down"])]
+
+        if "fast_col" not in current_params:
+            if line_cols:
+                resolved["fast_col"] = line_cols[0]
+            elif positive_cols:
+                resolved["fast_col"] = positive_cols[0]
+            elif new_cols:
+                resolved["fast_col"] = new_cols[0]
+
+        if "slow_col" not in current_params:
+            if signal_cols:
+                resolved["slow_col"] = signal_cols[0]
+            elif negative_cols:
+                resolved["slow_col"] = negative_cols[0]
+            elif len(new_cols) > 1:
+                resolved["slow_col"] = new_cols[1]
+
+        return resolved
+
+    def get_required_columns(self) -> list:
+        """Return required columns for the crossover strategy."""
+        return [self.fast_col, self.slow_col]
+
+
+@VectorizedStrategyRegistry.register("zero_line", description="Buy when oscillator is above zero, sell when below")
+class ZeroLineStrategy(VectorizedTradingStrategy):
+    """Strategy for zero-centered oscillators such as ROC or CMF."""
+
+    def __init__(
+        self,
+        indicator_col: str,
+        threshold: float = 0.0,
+        allow_short: bool = True,
+        score_scale: float = None,
+    ):
+        self.indicator_col = indicator_col
+        self.threshold = threshold
+        self.allow_short = allow_short
+        self.score_scale = score_scale
+
+    def generate_signals(self, data: pd.DataFrame) -> pd.Series:
+        """Generate long/short signals from a zero-line oscillator."""
+        signals = pd.Series(SignalType.HOLD.value, index=data.index)
+        if self.indicator_col not in data.columns:
+            return signals
+
+        signals[data[self.indicator_col] > self.threshold] = SignalType.BUY.value
+        if self.allow_short:
+            signals[data[self.indicator_col] < -self.threshold] = SignalType.SELL.value
+
+        return signals
+
+    def generate_scores(self, data: pd.DataFrame) -> pd.Series:
+        """Generate continuous scores from a centered oscillator."""
+        if self.indicator_col not in data.columns:
+            return pd.Series(0.0, index=data.index)
+
+        values = data[self.indicator_col]
+        if self.score_scale is not None and self.score_scale != 0:
+            return (values / self.score_scale).clip(-1.0, 1.0).fillna(0.0)
+
+        return self._rolling_zscore(values, window=60).fillna(0.0)
+
+    @classmethod
+    def resolve_columns(cls, new_cols: List[str], current_params: Dict[str, Any]) -> Dict[str, Any]:
+        """Prefer oscillator-like columns when an indicator adds
+        multiple outputs."""
+        resolved: Dict[str, Any] = {}
+        if "indicator_col" in current_params or not new_cols:
+            return resolved
+
+        preferred = [c for c in new_cols if "_osc" in c.lower()]
+        if preferred:
+            resolved["indicator_col"] = preferred[0]
+        else:
+            resolved["indicator_col"] = new_cols[0]
+        return resolved
+
+    def get_required_columns(self) -> list:
+        """Return required columns for the zero-line strategy."""
+        return [self.indicator_col]
+
+
+@VectorizedStrategyRegistry.register("volatility_breakout", description="Buy on high-volatility breakouts (ATR)")
 class VolatilityBreakoutStrategy(VectorizedTradingStrategy):
     """Strategy for volatility indicators like ATR."""
 
@@ -279,7 +451,9 @@ class VolatilityBreakoutStrategy(VectorizedTradingStrategy):
         return [self.indicator_col]
 
 
-@VectorizedStrategyRegistry.register("bollinger_bands")
+@VectorizedStrategyRegistry.register(
+    "bollinger_bands", description="Mean reversion at Bollinger Band extremes via state machine"
+)
 class BollingerBandsStrategy(VectorizedTradingStrategy):
     """Strategy for Bollinger Bands - Mean reversion at bands"""
 
@@ -362,11 +536,28 @@ class BollingerBandsStrategy(VectorizedTradingStrategy):
 
         return scores.clip(-1.0, 1.0)
 
+    @classmethod
+    def resolve_columns(cls, new_cols: List[str], current_params: Dict[str, Any]) -> Dict[str, Any]:
+        """Wire BB_upper / BB_lower / BB_middle columns."""
+
+        def _find(substring: str) -> Any:
+            matches = [c for c in new_cols if substring in c]
+            return matches[0] if matches else None
+
+        resolved: Dict[str, Any] = {}
+        if "upper_col" not in current_params:
+            resolved["upper_col"] = _find("BB_upper")
+        if "lower_col" not in current_params:
+            resolved["lower_col"] = _find("BB_lower")
+        if "middle_col" not in current_params:
+            resolved["middle_col"] = _find("BB_middle")
+        return resolved
+
     def get_required_columns(self) -> list:
         return [self.lower_col, self.middle_col, self.upper_col, "Close"]
 
 
-@VectorizedStrategyRegistry.register("stochastic")
+@VectorizedStrategyRegistry.register("stochastic", description="Mean reversion via %K/%D stochastic crossover")
 class StochasticStrategy(VectorizedTradingStrategy):
     """Strategy for Stochastic Oscillator - Mean reversion"""
 
@@ -437,6 +628,21 @@ class StochasticStrategy(VectorizedTradingStrategy):
         scores = (50.0 - data[self.k_col]) / 50.0
         return scores.clip(-1.0, 1.0)
 
+    @classmethod
+    def resolve_columns(cls, new_cols: List[str], current_params: Dict[str, Any]) -> Dict[str, Any]:
+        """Wire STOCH_%K and optional STOCH_%D columns."""
+
+        def _find(substring: str) -> Any:
+            matches = [c for c in new_cols if substring in c]
+            return matches[0] if matches else None
+
+        resolved: Dict[str, Any] = {}
+        if "k_col" not in current_params:
+            resolved["k_col"] = _find("STOCH_%K")
+        if "d_col" not in current_params:
+            resolved["d_col"] = _find("STOCH_%D")
+        return resolved
+
     def get_required_columns(self) -> list:
         required = [self.k_col]
         if self.d_col:
@@ -444,63 +650,159 @@ class StochasticStrategy(VectorizedTradingStrategy):
         return required
 
 
-@VectorizedStrategyRegistry.register("obv_trend")
-class OnBalanceVolumeStrategy(VectorizedTradingStrategy):
-    """Strategy for On-Balance Volume - Trend following based on volume"""
+@VectorizedStrategyRegistry.register(
+    "flow_trend",
+    description="Trend following using a cumulative flow line versus its moving average",
+)
+class FlowTrendStrategy(VectorizedTradingStrategy):
+    """Strategy for cumulative flow lines such as OBV and ADL."""
 
-    def __init__(self, obv_col: str, allow_short: bool = True):
-        self.obv_col = obv_col
+    def __init__(self, indicator_col: str, ma_window: int = 20, allow_short: bool = True):
+        self.indicator_col = indicator_col
+        self.ma_window = ma_window
         self.allow_short = allow_short
 
     def generate_signals(self, data: pd.DataFrame) -> pd.Series:
-        """
-        Generate trading signals based on On-Balance Volume strategy. A
-        simple strategy is to buy when the OBV is rising and sell when
-        it's falling. We can use a moving average of OBV to determine
-        the trend.
-
-        Args:
-            data (pd.DataFrame): Input OHLCV data.
-
-        Returns:
-            pd.Series: Generated trading signals.
-        """
+        """Generate signals from a cumulative flow line relative to its
+        trend."""
         signals = pd.Series(SignalType.HOLD.value, index=data.index)
-
-        if self.obv_col not in data.columns:
+        if self.indicator_col not in data.columns:
             return signals
 
-        # Use a short-term moving average to identify the trend of OBV
-        obv_sma = data[self.obv_col].rolling(window=20).mean()
-
-        # Buy when OBV is above its moving average (upward trend)
-        buy_condition = data[self.obv_col] > obv_sma
-        signals[buy_condition] = SignalType.BUY.value
-
-        # Sell when OBV is below its moving average (downward trend)
+        baseline = data[self.indicator_col].rolling(window=self.ma_window).mean()
+        signals[data[self.indicator_col] > baseline] = SignalType.BUY.value
         if self.allow_short:
-            sell_condition = data[self.obv_col] < obv_sma
-            signals[sell_condition] = SignalType.SELL.value
+            signals[data[self.indicator_col] < baseline] = SignalType.SELL.value
 
         return signals
 
     def generate_scores(self, data: pd.DataFrame) -> pd.Series:
-        """
-        Generate continuous alpha scores.
-
-        Score = (OBV - OBV_SMA) / OBV_STD
-        Z-Score of OBV Trend.
-        """
-        if self.obv_col not in data.columns:
+        """Generate flow-trend scores by normalizing distance from the
+        rolling mean."""
+        if self.indicator_col not in data.columns:
             return pd.Series(0.0, index=data.index)
 
-        return self._rolling_zscore(data[self.obv_col], window=20)
+        values = data[self.indicator_col]
+        baseline = values.rolling(window=self.ma_window).mean()
+        spread = values - baseline
+        scale = values.rolling(window=self.ma_window).std().replace(0, np.nan)
+        scores = (spread / (scale + 1e-9)) / 3.0
+        return scores.clip(-1.0, 1.0).fillna(0.0)
+
+    def get_required_columns(self) -> list:
+        """Return required columns for the flow-trend strategy."""
+        return [self.indicator_col]
+
+
+@VectorizedStrategyRegistry.register("obv_trend", description="Trend following via OBV vs its 20-period moving average")
+class OnBalanceVolumeStrategy(FlowTrendStrategy):
+    """Strategy for On-Balance Volume - Trend following based on volume"""
+
+    def __init__(self, obv_col: str, allow_short: bool = True):
+        super().__init__(indicator_col=obv_col, ma_window=20, allow_short=allow_short)
+        self.obv_col = obv_col
+
+    @classmethod
+    def resolve_columns(cls, new_cols: List[str], current_params: Dict[str, Any]) -> Dict[str, Any]:
+        """Wire OBV column."""
+        resolved: Dict[str, Any] = {}
+        if "obv_col" not in current_params:
+            matches = [c for c in new_cols if "OBV" in c]
+            resolved["obv_col"] = matches[0] if matches else (new_cols[0] if new_cols else None)
+        return resolved
 
     def get_required_columns(self) -> list:
         return [self.obv_col]
 
 
-@VectorizedStrategyRegistry.register("adx_trend")
+@VectorizedStrategyRegistry.register(
+    "channel_breakout",
+    description="Buy on channel breakouts above the upper band and sell below the lower band",
+)
+class ChannelBreakoutStrategy(VectorizedTradingStrategy):
+    """Strategy for breakout channels such as Donchian and Keltner."""
+
+    def __init__(
+        self,
+        upper_col: str,
+        lower_col: str,
+        middle_col: str = None,
+        breakout_buffer: float = 0.0,
+        allow_short: bool = True,
+    ):
+        self.upper_col = upper_col
+        self.lower_col = lower_col
+        self.middle_col = middle_col
+        self.breakout_buffer = breakout_buffer
+        self.allow_short = allow_short
+
+    def generate_signals(self, data: pd.DataFrame) -> pd.Series:
+        """Generate persistent breakout signals from upper/lower channel
+        bands."""
+        signals = pd.Series(SignalType.HOLD.value, index=data.index)
+        required = [self.upper_col, self.lower_col, "Close"]
+        if not all(col in data.columns for col in required):
+            return signals
+
+        upper = data[self.upper_col] * (1.0 + self.breakout_buffer)
+        lower = data[self.lower_col] * (1.0 - self.breakout_buffer)
+        long_entries = data["Close"] > upper
+        short_entries = data["Close"] < lower
+
+        signals[long_entries] = SignalType.BUY.value
+        if self.allow_short:
+            signals[short_entries] = SignalType.SELL.value
+
+        signals = (
+            signals.astype(float)
+            .replace(SignalType.HOLD.value, float("nan"))
+            .ffill()
+            .fillna(SignalType.HOLD.value)
+            .astype(int)
+        )
+        return signals
+
+    def generate_scores(self, data: pd.DataFrame) -> pd.Series:
+        """Generate normalized channel-position scores relative to the
+        channel midpoint."""
+        required = [self.upper_col, self.lower_col, "Close"]
+        if not all(col in data.columns for col in required):
+            return pd.Series(0.0, index=data.index)
+
+        upper = data[self.upper_col]
+        lower = data[self.lower_col]
+        middle = data[self.middle_col] if self.middle_col and self.middle_col in data.columns else (upper + lower) / 2.0
+        half_width = ((upper - lower) / 2.0).replace(0, np.nan)
+        scores = (data["Close"] - middle) / (half_width + 1e-9)
+        return scores.clip(-1.0, 1.0).fillna(0.0)
+
+    @classmethod
+    def resolve_columns(cls, new_cols: List[str], current_params: Dict[str, Any]) -> Dict[str, Any]:
+        """Resolve channel band columns from indicator outputs."""
+        resolved: Dict[str, Any] = {}
+        if "upper_col" not in current_params:
+            upper = [c for c in new_cols if "upper" in c.lower()]
+            resolved["upper_col"] = upper[0] if upper else None
+        if "lower_col" not in current_params:
+            lower = [c for c in new_cols if "lower" in c.lower()]
+            resolved["lower_col"] = lower[0] if lower else None
+        if "middle_col" not in current_params:
+            middle = [c for c in new_cols if "mid" in c.lower() or "middle" in c.lower()]
+            if middle:
+                resolved["middle_col"] = middle[0]
+        return resolved
+
+    def get_required_columns(self) -> list:
+        """Return required columns for the breakout strategy."""
+        required = [self.upper_col, self.lower_col, "Close"]
+        if self.middle_col:
+            required.append(self.middle_col)
+        return required
+
+
+@VectorizedStrategyRegistry.register(
+    "adx_trend", description="Trade in DI direction only when ADX confirms strong trend"
+)
 class ADXTrendStrategy(VectorizedTradingStrategy):
     """Strategy for ADX Trend Strength."""
 
@@ -556,11 +858,35 @@ class ADXTrendStrategy(VectorizedTradingStrategy):
         scores = strength * direction
         return scores.clip(-1.0, 1.0)
 
+    @classmethod
+    def resolve_columns(cls, new_cols: List[str], current_params: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Wire ADX / ADX_pos / ADX_neg columns.
+
+        The ADX indicator writes columns named "ADX_{window}",
+        "ADX_pos_{window}", and "ADX_neg_{window}" — not "PDI"/"MDI".
+        """
+
+        def _find(substring: str) -> Any:
+            matches = [c for c in new_cols if substring in c]
+            return matches[0] if matches else None
+
+        resolved: Dict[str, Any] = {}
+        if "adx_col" not in current_params:
+            # "ADX_14" matches "ADX" but also "ADX_pos_14" — prefer exact prefix
+            adx_matches = [c for c in new_cols if c.startswith("ADX_") and "pos" not in c and "neg" not in c]
+            resolved["adx_col"] = adx_matches[0] if adx_matches else _find("ADX")
+        if "pdi_col" not in current_params:
+            resolved["pdi_col"] = _find("ADX_pos")
+        if "mdi_col" not in current_params:
+            resolved["mdi_col"] = _find("ADX_neg")
+        return resolved
+
     def get_required_columns(self) -> list:
         return [self.adx_col, self.pdi_col, self.mdi_col]
 
 
-@VectorizedStrategyRegistry.register("cci_reversal")
+@VectorizedStrategyRegistry.register("cci_reversal", description="Mean reversion when CCI crosses +/-100 threshold")
 class CCIStrategy(VectorizedTradingStrategy):
     """Strategy for Commodity Channel Index."""
 

--- a/src/quantrl_lab/alpha_research/base.py
+++ b/src/quantrl_lab/alpha_research/base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
+from typing import Any, Dict, List
 
 import pandas as pd
 
@@ -63,12 +64,55 @@ class VectorizedTradingStrategy(ABC):
     @abstractmethod
     def get_required_columns(self) -> list:
         """
-        Return list of required columns for this strategy.
+        Return the list of DataFrame columns this strategy needs.
 
-        Raises:
-            NotImplementedError: If not implemented
+        Called after instantiation to validate that all indicator-generated
+        columns were successfully resolved before signals are generated.
 
         Returns:
-            list: List of required column names
+            list: List of required column names (actual column strings, not
+                parameter names).
         """
         raise NotImplementedError
+
+    @classmethod
+    def resolve_columns(cls, new_cols: List[str], current_params: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Resolve indicator-generated column names into constructor
+        kwargs.
+
+        A-7: Each strategy owns its own column-wiring logic so that
+        ``AlphaRunner._resolve_strategy_args`` is a simple one-line dispatch
+        rather than a long per-strategy if-chain.  Override in subclasses
+        that need multi-column wiring (MACD, Bollinger Bands, Stochastic,
+        ADX).  The default implementation handles the common single-column
+        case (``indicator_col``).
+
+        Args:
+            new_cols: Columns added to the DataFrame by the indicator step.
+            current_params: Strategy params already supplied by the user
+                (never overridden).
+
+        Returns:
+            Dict of additional kwargs to pass to the strategy constructor.
+        """
+        resolved: Dict[str, Any] = {}
+        if "indicator_col" not in current_params and new_cols:
+            resolved["indicator_col"] = new_cols[0]
+        return resolved
+
+    def validate_columns(self, data: pd.DataFrame) -> List[str]:
+        """
+        Return a list of required columns that are missing from *data*.
+
+        A-2: Enables ``AlphaRunner`` to warn early when column wiring
+        produced None values, rather than silently generating all-HOLD
+        signals.
+
+        Args:
+            data (pd.DataFrame): DataFrame after indicator calculation.
+
+        Returns:
+            List of missing column names (empty list when all present).
+        """
+        return [col for col in self.get_required_columns() if col is not None and col not in data.columns]

--- a/src/quantrl_lab/alpha_research/converters.py
+++ b/src/quantrl_lab/alpha_research/converters.py
@@ -1,11 +1,46 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
+
+import pandas as pd
 
 from quantrl_lab.alpha_research.models import AlphaResult
+
+LOWER_IS_BETTER_METRICS = {
+    "ic_p_value",
+    "rank_ic_p_value",
+    "feature_ic_p_value",
+    "feature_rank_ic_p_value",
+    "signal_ic_p_value",
+    "signal_rank_ic_p_value",
+}
+
+
+def metric_prefers_lower_values(metric: str) -> bool:
+    """Return whether lower values are better for the given metric."""
+    return metric in LOWER_IS_BETTER_METRICS
+
+
+def metric_threshold_passes(metric_value: float, threshold: float, metric: str) -> bool:
+    """Return whether a metric value passes the configured threshold."""
+    if metric_value is None or pd.isna(metric_value):
+        return False
+    if metric_prefers_lower_values(metric):
+        return metric_value <= threshold
+    return metric_value >= threshold
+
+
+def sort_alpha_results(results: List[AlphaResult], metric: str) -> List[AlphaResult]:
+    """Sort alpha results by metric with the correct direction."""
+    default_value = float("inf") if metric_prefers_lower_values(metric) else float("-inf")
+    return sorted(
+        results,
+        key=lambda result: result.metrics.get(metric, default_value),
+        reverse=not metric_prefers_lower_values(metric),
+    )
 
 
 def results_to_pipeline_config(
     results: List[AlphaResult], top_n: int = 5, metric: str = "ic", deduplicate: bool = False
-) -> List[Union[str, Dict[str, Any]]]:
+) -> List[Dict[str, Any]]:
     """
     Convert Alpha Research results into a DataPipeline configuration.
 
@@ -26,9 +61,9 @@ def results_to_pipeline_config(
             name).
 
     Returns:
-        List[Union[str, Dict[str, Any]]]: A list of indicator configurations
-        compatible with TechnicalIndicatorStep.
-        Example: [{"RSI": {"window": 14}}, {"SMA": {"window": 50}}]
+        List[Dict[str, Any]]: A list of indicator configurations compatible
+        with TechnicalIndicatorStep. Always dict format, e.g.
+        ``[{"RSI": {"window": 14}}, {"SMA": {"window": 50}}, {"OBV": {}}]``.
     """
     if not results:
         return []
@@ -39,8 +74,8 @@ def results_to_pipeline_config(
     if not completed_jobs:
         return []
 
-    # Sort by metric descending (missing metric defaults to -inf)
-    sorted_results = sorted(completed_jobs, key=lambda x: x.metrics.get(metric, float("-inf")), reverse=True)
+    # Sort by metric using its correct optimization direction.
+    sorted_results = sort_alpha_results(completed_jobs, metric=metric)
 
     if deduplicate:
         # Keep only the highest-scoring result per indicator name.
@@ -62,12 +97,8 @@ def results_to_pipeline_config(
         indicator_name = result.job.indicator_name
         params = result.job.indicator_params
 
-        # Format: {"IndicatorName": {params}}
-        # Dict format is always used when params are non-empty so the exact
-        # research params (not registry defaults) are preserved downstream.
-        if params:
-            pipeline_config.append({indicator_name: params})
-        else:
-            pipeline_config.append(indicator_name)
+        # Always use dict format so the exact research params are preserved
+        # downstream by TechnicalIndicatorStep, even when params is empty.
+        pipeline_config.append({indicator_name: params})
 
     return pipeline_config

--- a/src/quantrl_lab/alpha_research/indicator_research.py
+++ b/src/quantrl_lab/alpha_research/indicator_research.py
@@ -1,0 +1,282 @@
+"""Research metadata for technical indicators used by alpha
+selection."""
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from quantrl_lab.data.indicators import IndicatorRegistry
+
+FEATURE_SELECTION_MODE = "feature"
+STRATEGY_SELECTION_MODE = "strategy"
+SUPPORTED_SELECTION_MODES = (FEATURE_SELECTION_MODE, STRATEGY_SELECTION_MODE)
+
+
+@dataclass
+class IndicatorResearchMetadata:
+    """
+    Metadata describing how an indicator participates in alpha research.
+
+    Attributes:
+        name: Indicator registry key.
+        strategy_name: Strategy registry key used to evaluate this indicator.
+        strategy_params: Static constructor kwargs for the strategy.
+        default_candidates: Default parameter grid for selector sweeps.
+        supported_modes: Supported selection modes (feature and/or strategy).
+        notes: Short rationale or caveat for research usage.
+    """
+
+    name: str
+    strategy_name: Optional[str] = None
+    strategy_params: Dict[str, Any] = field(default_factory=dict)
+    default_candidates: List[Dict[str, Any]] = field(default_factory=lambda: [{}])
+    supported_modes: Tuple[str, ...] = SUPPORTED_SELECTION_MODES
+    notes: str = ""
+
+    def supports_mode(self, selection_mode: str) -> bool:
+        """Return whether this indicator is supported for the requested
+        mode."""
+        return self.strategy_name is not None and selection_mode in self.supported_modes
+
+
+def _meta(
+    name: str,
+    strategy_name: str,
+    *,
+    strategy_params: Optional[Dict[str, Any]] = None,
+    default_candidates: Optional[List[Dict[str, Any]]] = None,
+    supported_modes: Tuple[str, ...] = SUPPORTED_SELECTION_MODES,
+    notes: str = "",
+) -> IndicatorResearchMetadata:
+    """Construct indicator research metadata with concise defaults."""
+    return IndicatorResearchMetadata(
+        name=name,
+        strategy_name=strategy_name,
+        strategy_params=strategy_params or {},
+        default_candidates=default_candidates or [{}],
+        supported_modes=supported_modes,
+        notes=notes,
+    )
+
+
+INDICATOR_RESEARCH_METADATA: Dict[str, IndicatorResearchMetadata] = {
+    "SMA": _meta(
+        "SMA",
+        "trend_following",
+        default_candidates=[{"window": 20}, {"window": 50}, {"window": 200}],
+        notes="Price-relative trend filter.",
+    ),
+    "EMA": _meta(
+        "EMA",
+        "trend_following",
+        default_candidates=[{"window": 12}, {"window": 26}, {"window": 50}],
+        notes="Faster trend filter than SMA.",
+    ),
+    "RSI": _meta(
+        "RSI",
+        "mean_reversion",
+        strategy_params={"oversold": 30, "overbought": 70},
+        default_candidates=[{"window": 7}, {"window": 14}, {"window": 21}],
+    ),
+    "MACD": _meta(
+        "MACD",
+        "crossover",
+        strategy_params={"score_normalization": "close_pct"},
+        default_candidates=[{"fast": 12, "slow": 26, "signal": 9}, {"fast": 5, "slow": 35, "signal": 5}],
+    ),
+    "ATR": _meta(
+        "ATR",
+        "volatility_breakout",
+        default_candidates=[{"window": 14}],
+        notes="Volatility regime screen rather than direct directional feature.",
+    ),
+    "BB": _meta(
+        "BB",
+        "bollinger_bands",
+        default_candidates=[{"window": 20, "num_std": 2.0}],
+    ),
+    "STOCH": _meta(
+        "STOCH",
+        "stochastic",
+        default_candidates=[{"k_window": 14, "d_window": 3}],
+    ),
+    "OBV": _meta(
+        "OBV",
+        "flow_trend",
+        strategy_params={"ma_window": 20},
+        default_candidates=[{}],
+    ),
+    "WILLR": _meta(
+        "WILLR",
+        "mean_reversion",
+        strategy_params={"oversold": -80, "overbought": -20, "indicator_scale": "williams_r"},
+        default_candidates=[{"window": 14}],
+    ),
+    "CCI": _meta(
+        "CCI",
+        "cci_reversal",
+        strategy_params={"threshold": 100.0},
+        default_candidates=[{"window": 20}],
+    ),
+    "MFI": _meta(
+        "MFI",
+        "mean_reversion",
+        strategy_params={"oversold": 20, "overbought": 80},
+        default_candidates=[{"window": 14}],
+    ),
+    "ADX": _meta(
+        "ADX",
+        "adx_trend",
+        strategy_params={"threshold": 25.0},
+        default_candidates=[{"window": 14}],
+    ),
+    "ROC": _meta(
+        "ROC",
+        "zero_line",
+        default_candidates=[{"window": 12}, {"window": 20}],
+    ),
+    "PPO": _meta(
+        "PPO",
+        "crossover",
+        strategy_params={"score_normalization": "zscore"},
+        default_candidates=[{"fast": 12, "slow": 26, "signal": 9}],
+    ),
+    "TRIX": _meta(
+        "TRIX",
+        "crossover",
+        strategy_params={"score_normalization": "zscore"},
+        default_candidates=[{"window": 15, "signal": 9}, {"window": 30, "signal": 9}],
+    ),
+    "TSI": _meta(
+        "TSI",
+        "crossover",
+        strategy_params={"score_normalization": "zscore"},
+        default_candidates=[{"slow": 25, "fast": 13, "signal": 13}],
+    ),
+    "AROON": _meta(
+        "AROON",
+        "zero_line",
+        strategy_params={"score_scale": 100.0},
+        default_candidates=[{"window": 25}],
+    ),
+    "VORTEX": _meta(
+        "VORTEX",
+        "crossover",
+        strategy_params={"score_normalization": "zscore"},
+        default_candidates=[{"window": 14}],
+    ),
+    "DONCHIAN": _meta(
+        "DONCHIAN",
+        "channel_breakout",
+        default_candidates=[{"window": 20}, {"window": 55}],
+    ),
+    "KELTNER": _meta(
+        "KELTNER",
+        "channel_breakout",
+        default_candidates=[{"window": 20, "atr_mult": 2.0}],
+    ),
+    "NATR": _meta(
+        "NATR",
+        "volatility_breakout",
+        default_candidates=[{"window": 14}],
+        notes="Normalized volatility regime screen.",
+    ),
+    "CMF": _meta(
+        "CMF",
+        "zero_line",
+        strategy_params={"score_scale": 0.5},
+        default_candidates=[{"window": 20}],
+    ),
+    "ADL": _meta(
+        "ADL",
+        "flow_trend",
+        strategy_params={"ma_window": 20},
+        default_candidates=[{}],
+    ),
+    "CHO": _meta(
+        "CHO",
+        "zero_line",
+        default_candidates=[{"fast": 3, "slow": 10}],
+    ),
+    "SUPERTREND": _meta(
+        "SUPERTREND",
+        "trend_following",
+        default_candidates=[{"window": 10, "multiplier": 3.0}],
+    ),
+}
+
+
+def validate_selection_mode(selection_mode: str) -> str:
+    """Validate and normalize a selection mode string."""
+    if selection_mode not in SUPPORTED_SELECTION_MODES:
+        raise ValueError(
+            f"Unknown selection_mode: {selection_mode}. " f"Supported modes: {list(SUPPORTED_SELECTION_MODES)}"
+        )
+    return selection_mode
+
+
+def get_indicator_research_metadata(indicator_name: str) -> IndicatorResearchMetadata:
+    """Return research metadata for one indicator."""
+    name = indicator_name.upper()
+    if name not in INDICATOR_RESEARCH_METADATA:
+        raise KeyError(f"Indicator '{indicator_name}' does not have research metadata.")
+    return INDICATOR_RESEARCH_METADATA[name]
+
+
+def list_supported_indicators(selection_mode: Optional[str] = None) -> List[str]:
+    """List indicators supported by alpha research, optionally by
+    mode."""
+    if selection_mode is None:
+        return list(INDICATOR_RESEARCH_METADATA.keys())
+
+    validated_mode = validate_selection_mode(selection_mode)
+    return [name for name, metadata in INDICATOR_RESEARCH_METADATA.items() if metadata.supports_mode(validated_mode)]
+
+
+def get_default_candidates(selection_mode: str = FEATURE_SELECTION_MODE) -> List[Dict[str, Any]]:
+    """Return the default candidate sweep for the requested selection
+    mode."""
+    validated_mode = validate_selection_mode(selection_mode)
+    candidates: List[Dict[str, Any]] = []
+    for name, metadata in INDICATOR_RESEARCH_METADATA.items():
+        if not metadata.supports_mode(validated_mode):
+            continue
+        for params in metadata.default_candidates:
+            candidates.append({"name": name, "params": deepcopy(params)})
+    return candidates
+
+
+def get_strategy_config(indicator_name: str, selection_mode: str = FEATURE_SELECTION_MODE) -> Optional[Dict[str, Any]]:
+    """Return strategy wiring for one indicator in the requested
+    mode."""
+    validated_mode = validate_selection_mode(selection_mode)
+    metadata = get_indicator_research_metadata(indicator_name)
+    if not metadata.supports_mode(validated_mode):
+        return None
+    return {"name": metadata.strategy_name, "params": deepcopy(metadata.strategy_params)}
+
+
+def _validate_registry_coverage():
+    """Ensure every registered indicator has explicit research
+    metadata."""
+    registered = set(IndicatorRegistry.list_all())
+    configured = set(INDICATOR_RESEARCH_METADATA.keys())
+    missing = registered - configured
+    extra = configured - registered
+    if missing or extra:
+        raise RuntimeError(
+            "Indicator research metadata is out of sync with IndicatorRegistry. "
+            f"Missing: {sorted(missing)} Extra: {sorted(extra)}"
+        )
+
+
+_validate_registry_coverage()
+
+
+# Compatibility view for older imports. Kept in the alpha layer, but now
+# derived from explicit research metadata rather than a free-floating map.
+INDICATOR_STRATEGY_MAP: Dict[str, Dict[str, Any]] = {
+    name: {"name": metadata.strategy_name, "params": deepcopy(metadata.strategy_params)}
+    for name, metadata in INDICATOR_RESEARCH_METADATA.items()
+    if metadata.strategy_name is not None
+}

--- a/src/quantrl_lab/alpha_research/integration.py
+++ b/src/quantrl_lab/alpha_research/integration.py
@@ -1,0 +1,184 @@
+"""Adapters for feeding alpha-research results into data processing."""
+
+import warnings
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import pandas as pd
+
+from quantrl_lab.data.partitioning import DateRangeSplitter, RatioSplitter
+from quantrl_lab.data.processing import ProcessingPipelineConfig, SplitConfig
+
+from .indicator_research import FEATURE_SELECTION_MODE, validate_selection_mode
+from .selector import AlphaSelector
+
+
+@dataclass
+class AlphaSelectionConfig:
+    """Configuration for alpha-driven indicator selection."""
+
+    candidates: Optional[List[Dict[str, Any]]] = None
+    metric: str = "ic"
+    threshold: float = 0.0
+    top_k: int = 5
+    selection_mode: str = FEATURE_SELECTION_MODE
+
+    def __post_init__(self):
+        """Validate the requested selection mode."""
+        self.selection_mode = validate_selection_mode(self.selection_mode)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return plain dictionary form for selector calls and
+        metadata."""
+        return {
+            "candidates": self.candidates,
+            "metric": self.metric,
+            "threshold": self.threshold,
+            "top_k": self.top_k,
+            "selection_mode": self.selection_mode,
+        }
+
+
+def _coerce_selection_config(
+    alpha_selection_config: Union[AlphaSelectionConfig, Dict[str, Any]],
+) -> AlphaSelectionConfig:
+    """Normalize selection config to the typed dataclass."""
+    if isinstance(alpha_selection_config, AlphaSelectionConfig):
+        return alpha_selection_config
+    if isinstance(alpha_selection_config, dict):
+        return AlphaSelectionConfig(**alpha_selection_config)
+    raise TypeError("alpha_selection_config must be a dict or AlphaSelectionConfig.")
+
+
+def _coerce_split_config(split_config: Optional[Union[SplitConfig, Dict[str, Any]]]) -> Optional[SplitConfig]:
+    """Normalize split config to the typed dataclass."""
+    if split_config is None:
+        return None
+    if isinstance(split_config, SplitConfig):
+        return split_config
+    if isinstance(split_config, dict):
+        return SplitConfig(splits=split_config)
+    raise TypeError("split_config must be a dict or SplitConfig.")
+
+
+def _has_multiple_symbols(df: pd.DataFrame) -> bool:
+    """Return True when the dataframe contains more than one symbol."""
+    return "Symbol" in df.columns and df["Symbol"].dropna().nunique() > 1
+
+
+def _split_raw_data(df: pd.DataFrame, split_config: Dict[str, Any]) -> Dict[str, pd.DataFrame]:
+    """Split raw data using the same date/index handling as
+    DataProcessor."""
+    original_index_name = df.index.name
+    index_name = original_index_name or "Date"
+    has_datetime_index = hasattr(df.index, "dtype") and pd.api.types.is_datetime64_any_dtype(df.index)
+    if has_datetime_index:
+        df = df.reset_index()
+        if df.columns[0] != index_name:
+            df = df.rename(columns={df.columns[0]: index_name})
+
+    splitter = (
+        DateRangeSplitter(split_config)
+        if any(isinstance(v, (tuple, list)) for v in split_config.values())
+        else RatioSplitter(split_config)
+    )
+    split_data = splitter.split(df)
+
+    if has_datetime_index:
+        for key, split_df in split_data.items():
+            if index_name in split_df.columns:
+                split_data[key] = split_df.set_index(index_name)
+                split_data[key].index.name = original_index_name
+
+    return split_data
+
+
+def select_indicators_for_processing(
+    raw_data: pd.DataFrame,
+    alpha_selection_config: Union[AlphaSelectionConfig, Dict[str, Any]],
+    *,
+    split_config: Optional[Union[SplitConfig, Dict[str, Any]]] = None,
+    verbose: bool = False,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """
+    Select processing indicators from raw OHLCV data outside
+    ``DataProcessor``.
+
+    When ``split_config`` is provided, selection runs on the raw training split
+    to avoid leakage.
+    """
+    if _has_multiple_symbols(raw_data):
+        raise ValueError(
+            "select_indicators_for_processing only supports single-symbol data. "
+            "Use AlphaSelector.suggest_for_universe() for multi-symbol workflows."
+        )
+
+    selection_config = _coerce_selection_config(alpha_selection_config)
+    selection_metadata = selection_config.to_dict()
+    coerced_split = _coerce_split_config(split_config)
+
+    if coerced_split is None:
+        warnings.warn(
+            "Selecting indicators without split_config uses the full dataset and may leak future information. "
+            "Prefer selecting on an explicit training split.",
+            UserWarning,
+            stacklevel=2,
+        )
+        selection_data = raw_data
+        selection_metadata["selected_from_split"] = "full_data"
+    else:
+        split_dict = coerced_split.to_dict()
+        if "train" not in split_dict:
+            raise ValueError("alpha selection for processing requires split_config to include a 'train' split.")
+        split_data = _split_raw_data(raw_data, split_dict)
+        if "train" not in split_data or split_data["train"].empty:
+            raise ValueError("Training split for alpha selection is empty.")
+        selection_data = split_data["train"]
+        selection_metadata["selected_from_split"] = "train"
+
+    selection_metadata["selection_rows"] = len(selection_data)
+    selection_metadata["selection_verbose"] = verbose
+
+    selector = AlphaSelector(selection_data, verbose=verbose)
+    indicators = selector.suggest_indicators(
+        candidates=selection_config.candidates,
+        metric=selection_config.metric,
+        threshold=selection_config.threshold,
+        top_k=selection_config.top_k,
+        selection_mode=selection_config.selection_mode,
+    )
+    return indicators, selection_metadata
+
+
+def build_processing_config_from_alpha_selection(
+    raw_data: pd.DataFrame,
+    alpha_selection_config: Union[AlphaSelectionConfig, Dict[str, Any]],
+    *,
+    split_config: Optional[Union[SplitConfig, Dict[str, Any]]] = None,
+    processing_config: Optional[ProcessingPipelineConfig] = None,
+    verbose: bool = False,
+) -> Tuple[ProcessingPipelineConfig, Dict[str, Any]]:
+    """Build a ``ProcessingPipelineConfig`` populated with alpha-
+    selected indicators."""
+    resolved_config = deepcopy(processing_config) if processing_config is not None else ProcessingPipelineConfig()
+    if resolved_config.indicators is not None:
+        raise ValueError("processing_config.indicators must be None when building it from alpha selection.")
+
+    coerced_split = _coerce_split_config(split_config)
+    if coerced_split is not None:
+        if resolved_config.split is not None and resolved_config.split.to_dict() != coerced_split.to_dict():
+            raise ValueError("split_config conflicts with processing_config.split.")
+        resolved_config.split = coerced_split
+
+    selection_verbose = verbose or resolved_config.verbose
+    indicators, selection_metadata = select_indicators_for_processing(
+        raw_data,
+        alpha_selection_config,
+        split_config=resolved_config.split,
+        verbose=selection_verbose,
+    )
+
+    resolved_config.indicators = indicators
+    resolved_config.verbose = selection_verbose
+    return resolved_config, selection_metadata

--- a/src/quantrl_lab/alpha_research/metrics.py
+++ b/src/quantrl_lab/alpha_research/metrics.py
@@ -37,6 +37,10 @@ def calculate_information_coefficient(signal: pd.Series, forward_returns: pd.Ser
     if len(df) < 2:
         return 0.0
 
+    # A-8: constant signal or returns → correlation is undefined (NaN) → treat as 0
+    if df.iloc[:, 0].nunique() <= 1 or df.iloc[:, 1].nunique() <= 1:
+        return 0.0
+
     return df.iloc[:, 0].corr(df.iloc[:, 1])
 
 
@@ -53,6 +57,10 @@ def calculate_pearson_ic(signal: pd.Series, forward_returns: pd.Series) -> Tuple
     """
     df = pd.concat([signal, forward_returns], axis=1).dropna()
     if len(df) < 2:
+        return 0.0, 1.0
+
+    # A-8: constant signal or returns → correlation is undefined (NaN) → treat as 0
+    if df.iloc[:, 0].nunique() <= 1 or df.iloc[:, 1].nunique() <= 1:
         return 0.0, 1.0
 
     ic, p_value = pearsonr(df.iloc[:, 0], df.iloc[:, 1])
@@ -76,6 +84,10 @@ def calculate_rank_ic(signal: pd.Series, forward_returns: pd.Series) -> Tuple[fl
     """
     df = pd.concat([signal, forward_returns], axis=1).dropna()
     if len(df) < 2:
+        return 0.0, 1.0
+
+    # A-8: constant signal or returns → correlation is undefined (NaN) → treat as 0
+    if df.iloc[:, 0].nunique() <= 1 or df.iloc[:, 1].nunique() <= 1:
         return 0.0, 1.0
 
     correlation, p_value = spearmanr(df.iloc[:, 0], df.iloc[:, 1])

--- a/src/quantrl_lab/alpha_research/models.py
+++ b/src/quantrl_lab/alpha_research/models.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, Optional
 
 import pandas as pd
 
+from .indicator_research import STRATEGY_SELECTION_MODE, validate_selection_mode
+
 
 @dataclass
 class AlphaJob:
@@ -15,9 +17,17 @@ class AlphaJob:
     indicator_params: Dict[str, Any] = field(default_factory=dict)  # e.g. {"window": 14}
     strategy_params: Dict[str, Any] = field(default_factory=dict)  # e.g. {"oversold": 30}
     allow_short: bool = True
+    evaluation_mode: str = STRATEGY_SELECTION_MODE
 
     id: str = field(default_factory=lambda: str(uuid.uuid4())[:8])
     tags: Dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self):
+        if not self.indicator_name or not self.indicator_name.strip():
+            raise ValueError("indicator_name must be a non-empty string")
+        if not self.strategy_name or not self.strategy_name.strip():
+            raise ValueError("strategy_name must be a non-empty string")
+        self.evaluation_mode = validate_selection_mode(self.evaluation_mode)
 
 
 @dataclass
@@ -28,5 +38,6 @@ class AlphaResult:
     metrics: Dict[str, Any]
     equity_curve: Optional[pd.Series] = None
     signals: Optional[pd.Series] = None
+    scores: Optional[pd.Series] = None
     status: str = "completed"
     error: Optional[str] = None

--- a/src/quantrl_lab/alpha_research/registry.py
+++ b/src/quantrl_lab/alpha_research/registry.py
@@ -1,19 +1,67 @@
-from typing import Callable, Dict, List, Type
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Type
 
 from .base import VectorizedTradingStrategy
+
+
+@dataclass
+class StrategyMetadata:
+    """
+    Metadata for a registered vectorized trading strategy.
+
+    A-7: Mirrors ``IndicatorMetadata`` in the data layer so the strategy
+    registry is self-describing and tooling (e.g., auto-wiring, docs) can
+    introspect strategies without importing every strategy class.
+
+    Attributes:
+        name (str): Registry key (e.g., ``"mean_reversion"``).
+        strategy_class (Type[VectorizedTradingStrategy]): The concrete class.
+        description (str): Human-readable description of the strategy logic.
+        default_params (Dict[str, Any]): Default constructor kwargs
+            (excluding column args, which are resolved at runtime).
+    """
+
+    name: str
+    strategy_class: Type[VectorizedTradingStrategy]
+    description: str = ""
+    default_params: Dict[str, Any] = field(default_factory=dict)
 
 
 class VectorizedStrategyRegistry:
     """Registry for vectorized trading strategies."""
 
-    _strategies: Dict[str, Type[VectorizedTradingStrategy]] = {}
+    _strategies: Dict[str, StrategyMetadata] = {}
 
     @classmethod
-    def register(cls, name: str) -> Callable:
-        """Decorator to register a strategy class."""
+    def register(cls, name: str, description: str = "", default_params: Optional[Dict[str, Any]] = None) -> Callable:
+        """
+        Decorator to register a strategy class with metadata.
+
+        Args:
+            name (str): Registry key for the strategy.
+            description (str): Human-readable description.
+            default_params (Dict[str, Any], optional): Default constructor
+                kwargs (excluding column args).
+
+        Returns:
+            Callable: Decorator that registers the strategy class.
+        """
 
         def decorator(strategy_class: Type[VectorizedTradingStrategy]):
-            cls._strategies[name] = strategy_class
+            if name in cls._strategies:
+                import warnings
+
+                warnings.warn(
+                    f"Strategy '{name}' is already registered and will be overwritten.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            cls._strategies[name] = StrategyMetadata(
+                name=name,
+                strategy_class=strategy_class,
+                description=description,
+                default_params=default_params or {},
+            )
             return strategy_class
 
         return decorator
@@ -23,11 +71,29 @@ class VectorizedStrategyRegistry:
         """Create a strategy instance by name."""
         if name not in cls._strategies:
             raise ValueError(f"Unknown strategy: {name}. Available: {list(cls._strategies.keys())}")
-        return cls._strategies[name](**kwargs)
+        return cls._strategies[name].strategy_class(**kwargs)
 
     @classmethod
     def get(cls, name: str) -> Type[VectorizedTradingStrategy]:
         """Get the strategy class by name."""
+        if name not in cls._strategies:
+            raise ValueError(f"Unknown strategy: {name}. Available: {list(cls._strategies.keys())}")
+        return cls._strategies[name].strategy_class
+
+    @classmethod
+    def get_metadata(cls, name: str) -> StrategyMetadata:
+        """
+        Get the full metadata for a strategy.
+
+        Args:
+            name (str): Registry key for the strategy.
+
+        Raises:
+            ValueError: If the strategy is not registered.
+
+        Returns:
+            StrategyMetadata: Metadata object for the strategy.
+        """
         if name not in cls._strategies:
             raise ValueError(f"Unknown strategy: {name}. Available: {list(cls._strategies.keys())}")
         return cls._strategies[name]

--- a/src/quantrl_lab/alpha_research/runner.py
+++ b/src/quantrl_lab/alpha_research/runner.py
@@ -10,6 +10,7 @@ from sklearn.feature_selection import mutual_info_regression
 
 from quantrl_lab.data.indicators.registry import IndicatorRegistry
 
+from .indicator_research import FEATURE_SELECTION_MODE
 from .metrics import (
     calculate_forward_returns,
     calculate_pearson_ic,
@@ -17,6 +18,9 @@ from .metrics import (
 )
 from .models import AlphaJob, AlphaResult
 from .registry import VectorizedStrategyRegistry
+
+# IndicatorRegistry is used by _calculate_indicators; kept as a named import
+# so the import is explicit even though resolve_columns no longer uses it.
 
 console = Console()
 
@@ -49,11 +53,12 @@ class AlphaRunner:
 
         try:
             # 1. Validate Data
-            self._validate_data(job.data)
+            # Returns a (possibly column-normalised) copy — never the original job.data
+            validated_data = self._validate_data(job.data)
 
             # 2. Calculate Indicators
-            old_cols = set(job.data.columns)
-            data_with_indicators = self._calculate_indicators(job.data, job.indicator_name, job.indicator_params)
+            old_cols = set(validated_data.columns)
+            data_with_indicators = self._calculate_indicators(validated_data, job.indicator_name, job.indicator_params)
             new_cols = list(set(data_with_indicators.columns) - old_cols)
 
             # 3. Create Strategy
@@ -63,18 +68,47 @@ class AlphaRunner:
                 if param in strategy_params:
                     del strategy_params[param]
 
-            # Resolve strategy specific column arguments (pass indicator_name for registry lookup)
+            # A-7: Delegate column wiring to the strategy class itself.
+            # Each strategy implements resolve_columns() so this runner no
+            # longer needs a per-strategy if-chain.
             strategy_cls = VectorizedStrategyRegistry.get(job.strategy_name)
-            resolved_args = self._resolve_strategy_args(
-                strategy_cls, new_cols, strategy_params, indicator_name=job.indicator_name
-            )
+            resolved_args = strategy_cls.resolve_columns(new_cols, strategy_params)
             strategy_params.update(resolved_args)
 
             strategy = VectorizedStrategyRegistry.create(
                 job.strategy_name, allow_short=job.allow_short, **strategy_params
             )
 
+            # A-2: Validate that all required columns are present before generating
+            # signals. Catches broken wiring early instead of silently returning
+            # all-HOLD signals (which score zero IC and waste the whole job run).
+            missing_cols = strategy.validate_columns(data_with_indicators)
+            if missing_cols and self.verbose:
+                console.print(
+                    f"[yellow]Warning: {job.strategy_name} for {job.indicator_name} "
+                    f"is missing columns {missing_cols}. Signals will default to HOLD.[/yellow]"
+                )
+
             # 4. Generate Signals
+            analysis_horizon = job.strategy_params.get("ic_horizon", 5)
+
+            if job.evaluation_mode == FEATURE_SELECTION_MODE:
+                scores = strategy.generate_scores(data_with_indicators)
+                feature_metrics = self._analyze_predictive_power(
+                    data_with_indicators,
+                    scores,
+                    horizon=analysis_horizon,
+                    prefix="feature_",
+                )
+                feature_metrics.update(self._summarize_scores(scores))
+                feature_metrics.update(self._alias_primary_metrics(feature_metrics, prefix="feature_"))
+                return AlphaResult(
+                    job=job,
+                    metrics=feature_metrics,
+                    scores=scores,
+                    status="completed",
+                )
+
             signals = strategy.generate_signals(data_with_indicators)
 
             # 5. Simulate Portfolio
@@ -86,13 +120,17 @@ class AlphaRunner:
             )
 
             # 6. Statistical Signal Analysis (IC, etc.)
-            signal_analysis = self._analyze_signal_predictive_power(
-                data_with_indicators, signals, horizon=job.strategy_params.get("ic_horizon", 5)
+            signal_analysis = self._analyze_predictive_power(
+                data_with_indicators,
+                signals,
+                horizon=analysis_horizon,
+                prefix="signal_",
             )
 
             # 7. Metrics
             metrics = self._calculate_metrics(portfolio_results)
             metrics.update(signal_analysis)
+            metrics.update(self._alias_primary_metrics(signal_analysis, prefix="signal_"))
 
             return AlphaResult(
                 job=job,
@@ -108,112 +146,6 @@ class AlphaRunner:
                 console.print(f"[red]Job Failed: {e}[/red]")
                 console.print(tb)
             return AlphaResult(job=job, metrics={}, status="failed", error=tb)
-
-    def _resolve_strategy_args(
-        self,
-        strategy_cls: Any,
-        new_cols: List[str],
-        current_params: Dict[str, Any],
-        indicator_name: str = "",
-    ) -> Dict[str, Any]:
-        """
-        Resolve column arguments for strategy from indicator-generated
-        columns.
-
-        Uses ``IndicatorRegistry`` metadata (``output_columns``) as the
-        authoritative source of column names, so that strategy wiring does not
-        break when the registry changes its naming conventions.  Hardcoded
-        substring matching is kept only as a last-resort fallback for
-        indicators registered without explicit ``output_columns``.
-
-        Args:
-            strategy_cls: The strategy class to instantiate.
-            new_cols: Columns added to the DataFrame by the indicator calculation.
-            current_params: Strategy parameters already supplied by the user
-                (these are never overridden).
-            indicator_name: Registry name of the indicator, used to fetch
-                ``IndicatorMetadata.output_columns`` (optional but recommended).
-
-        Returns:
-            Dict[str, Any]: Additional keyword arguments to pass to the strategy.
-        """
-        import inspect
-
-        init_signature = inspect.signature(strategy_cls.__init__)
-        init_params = init_signature.parameters
-        resolved = {}
-
-        # --- Registry-aware column lookup ---
-        # Prefer metadata.output_columns over substring guessing so the wiring
-        # stays valid even if the registry renames its output columns.
-        registry_cols: List[str] = []
-        if indicator_name:
-            try:
-                meta = IndicatorRegistry.get_metadata(indicator_name)
-                # Only keep columns that were actually added to the DataFrame
-                registry_cols = [c for c in meta.output_columns if c in new_cols]
-            except KeyError:
-                pass  # Unknown indicator — fall back to substring heuristics
-
-        def find_col(substring: str) -> Any:
-            """Fallback: find first new column whose name contains substring."""
-            matches = [c for c in new_cols if substring in c]
-            if not matches and self.verbose:
-                console.print(
-                    f"[yellow]Warning: could not resolve column for '{substring}' "
-                    f"in indicator '{indicator_name}'. New columns: {new_cols}[/yellow]"
-                )
-            return matches[0] if matches else None
-
-        def registry_col(substring: str) -> Any:
-            """Check registry columns first, then fall back to substring
-            search."""
-            matches = [c for c in registry_cols if substring in c]
-            return matches[0] if matches else find_col(substring)
-
-        # 1. Generic 'indicator_col' — single-output indicators (RSI, SMA, ATR, CCI…)
-        if "indicator_col" in init_params and "indicator_col" not in current_params:
-            if registry_cols:
-                resolved["indicator_col"] = registry_cols[0]
-            elif new_cols:
-                resolved["indicator_col"] = new_cols[0]
-
-        # 2. MACD: fast_col = MACD line, slow_col = Signal line
-        if "fast_col" in init_params and "slow_col" in init_params:
-            if "fast_col" not in current_params:
-                resolved["fast_col"] = registry_col("MACD_line")
-            if "slow_col" not in current_params:
-                resolved["slow_col"] = registry_col("MACD_signal")
-
-        # 3. Bollinger Bands: upper / lower / middle bands
-        if "upper_col" in init_params and "lower_col" in init_params:
-            if "upper_col" not in current_params:
-                resolved["upper_col"] = registry_col("BB_upper")
-            if "lower_col" not in current_params:
-                resolved["lower_col"] = registry_col("BB_lower")
-            if "middle_col" not in current_params and "middle_col" in init_params:
-                resolved["middle_col"] = registry_col("BB_middle")
-
-        # 4. Stochastic: %K and optional %D
-        if "k_col" in init_params:
-            if "k_col" not in current_params:
-                resolved["k_col"] = registry_col("STOCH_%K")
-            if "d_col" in init_params and "d_col" not in current_params:
-                resolved["d_col"] = registry_col("STOCH_%D")
-
-        # 5. OBV
-        if "obv_col" in init_params and "obv_col" not in current_params:
-            resolved["obv_col"] = registry_col("OBV")
-
-        # 6. ADX: adx_col / pdi_col / mdi_col
-        if "adx_col" in init_params and "adx_col" not in current_params:
-            resolved["adx_col"] = registry_col("ADX")
-        if "pdi_col" in init_params and "pdi_col" not in current_params:
-            resolved["pdi_col"] = registry_col("PDI")
-        if "mdi_col" in init_params and "mdi_col" not in current_params:
-            resolved["mdi_col"] = registry_col("MDI")
-
-        return resolved
 
     def run_batch(self, jobs: List[AlphaJob], n_jobs: int = 1) -> List[AlphaResult]:
         """
@@ -247,12 +179,25 @@ class AlphaRunner:
 
         return results
 
-    def _validate_data(self, data: pd.DataFrame) -> None:
+    def _validate_data(self, data: pd.DataFrame) -> pd.DataFrame:
         """
         Validate input data for required columns, types, and quality.
 
+        Returns a (possibly column-renamed) copy of the DataFrame rather than
+        mutating the caller's object in-place.
+
+        BUG FIX (A-3): The original implementation called
+        ``data.rename(columns=..., inplace=True)`` which mutated the shared
+        ``AlphaJob.data`` DataFrame directly. In batch runs where multiple jobs
+        reference the same DataFrame, this silently renamed columns under
+        subsequent jobs, causing them to fail with "missing column" errors.
+        The fix returns a new DataFrame so the caller's object is never touched.
+
         Args:
             data (pd.DataFrame): Input market data.
+
+        Returns:
+            pd.DataFrame: Validated (and if necessary, column-normalised) copy.
 
         Raises:
             ValueError: If validation fails.
@@ -278,7 +223,9 @@ class AlphaRunner:
         if rename_map:
             if self.verbose:
                 console.print(f"[yellow]Auto-normalising column names: {rename_map}[/yellow]")
-            data.rename(columns=rename_map, inplace=True)
+            # Return a renamed copy — do NOT mutate the caller's DataFrame
+            data = data.rename(columns=rename_map)
+
         if data.empty:
             raise ValueError("Data is empty")
 
@@ -301,6 +248,8 @@ class AlphaRunner:
             problematic_rows = (data["High"] < data["Low"]).sum()
             raise ValueError(f"Invalid data: High < Low in {problematic_rows} rows")
 
+        return data
+
     def _calculate_indicators(
         self, data: pd.DataFrame, indicator_name: str, indicator_params: Dict[str, Any]
     ) -> pd.DataFrame:
@@ -310,28 +259,38 @@ class AlphaRunner:
         except Exception as e:
             raise ValueError(f"Failed to calculate indicator {indicator_name}: {e}")
 
-    def _analyze_signal_predictive_power(
-        self, data: pd.DataFrame, signals: pd.Series, horizon: int = 5
+    def _analyze_predictive_power(
+        self,
+        data: pd.DataFrame,
+        values: pd.Series,
+        horizon: int = 5,
+        prefix: str = "",
     ) -> Dict[str, float]:
         """
-        Analyze the predictive power of signals using Information
-        Coefficient (IC).
+        Analyze predictive power using Information Coefficient (IC).
 
         Args:
             data (pd.DataFrame): Market data with Close prices.
-            signals (pd.Series): Trading signals.
+            values (pd.Series): Signals or continuous feature scores.
             horizon (int): Forward-looking horizon for returns (in periods).
+            prefix (str): Prefix for returned metric names.
 
         Returns:
             Dict[str, float]: Dictionary of signal quality metrics.
         """
         forward_returns = calculate_forward_returns(data["Close"], periods=horizon)
 
-        valid_mask = signals.notna() & forward_returns.notna()
+        valid_mask = values.notna() & forward_returns.notna()
         if not valid_mask.any():
-            return {"ic": 0.0, "rank_ic": 0.0, "ic_p_value": 1.0, "rank_ic_p_value": 1.0, "mutual_info": 0.0}
+            return {
+                f"{prefix}ic": 0.0,
+                f"{prefix}rank_ic": 0.0,
+                f"{prefix}ic_p_value": 1.0,
+                f"{prefix}rank_ic_p_value": 1.0,
+                f"{prefix}mutual_info": 0.0,
+            }
 
-        s = signals[valid_mask]
+        s = values[valid_mask]
         r = forward_returns[valid_mask]
 
         ic, ic_p = calculate_pearson_ic(s, r)
@@ -344,11 +303,34 @@ class AlphaRunner:
             mi = 0.0
 
         return {
-            "ic": float(ic),
-            "rank_ic": float(rank_ic),
-            "ic_p_value": float(ic_p),
-            "rank_ic_p_value": float(rank_ic_p),
-            "mutual_info": float(mi),
+            f"{prefix}ic": float(ic),
+            f"{prefix}rank_ic": float(rank_ic),
+            f"{prefix}ic_p_value": float(ic_p),
+            f"{prefix}rank_ic_p_value": float(rank_ic_p),
+            f"{prefix}mutual_info": float(mi),
+        }
+
+    def _alias_primary_metrics(self, metrics: Dict[str, float], prefix: str) -> Dict[str, float]:
+        """Expose the requested mode's predictive metrics under the
+        legacy names."""
+        aliased: Dict[str, float] = {}
+        for key in ["ic", "rank_ic", "ic_p_value", "rank_ic_p_value", "mutual_info"]:
+            prefixed_key = f"{prefix}{key}"
+            if prefixed_key in metrics:
+                aliased[key] = float(metrics[prefixed_key])
+        return aliased
+
+    def _summarize_scores(self, scores: pd.Series) -> Dict[str, float]:
+        """Return lightweight diagnostics for feature-mode score
+        distributions."""
+        clean_scores = scores.dropna()
+        if clean_scores.empty:
+            return {"score_mean": 0.0, "score_std": 0.0, "score_abs_mean": 0.0}
+
+        return {
+            "score_mean": float(clean_scores.mean()),
+            "score_std": float(clean_scores.std()),
+            "score_abs_mean": float(clean_scores.abs().mean()),
         }
 
     def _simulate_portfolio(

--- a/src/quantrl_lab/alpha_research/selector.py
+++ b/src/quantrl_lab/alpha_research/selector.py
@@ -1,14 +1,61 @@
+import json
 import uuid
 from typing import Dict, List, Optional
 
 import pandas as pd
 from rich.console import Console
 
-from quantrl_lab.alpha_research.converters import results_to_pipeline_config
+from quantrl_lab.alpha_research.converters import (
+    metric_threshold_passes,
+    results_to_pipeline_config,
+    sort_alpha_results,
+)
+from quantrl_lab.alpha_research.indicator_research import (
+    FEATURE_SELECTION_MODE,
+)
+from quantrl_lab.alpha_research.indicator_research import get_default_candidates as get_research_default_candidates
+from quantrl_lab.alpha_research.indicator_research import get_strategy_config as get_research_strategy_config
+from quantrl_lab.alpha_research.indicator_research import (
+    validate_selection_mode,
+)
 from quantrl_lab.alpha_research.models import AlphaJob
 from quantrl_lab.alpha_research.runner import AlphaRunner
 
 console = Console()
+
+FEATURE_MODE_METRICS = {
+    "ic",
+    "rank_ic",
+    "ic_p_value",
+    "rank_ic_p_value",
+    "mutual_info",
+    "feature_ic",
+    "feature_rank_ic",
+    "feature_ic_p_value",
+    "feature_rank_ic_p_value",
+    "feature_mutual_info",
+    "score_mean",
+    "score_std",
+    "score_abs_mean",
+}
+STRATEGY_MODE_METRICS = FEATURE_MODE_METRICS | {
+    "signal_ic",
+    "signal_rank_ic",
+    "signal_ic_p_value",
+    "signal_rank_ic_p_value",
+    "signal_mutual_info",
+    "total_return",
+    "annual_return",
+    "sharpe_ratio",
+    "sortino_ratio",
+    "calmar_ratio",
+    "max_drawdown",
+    "volatility",
+    "win_rate",
+    "win_loss_ratio",
+    "profit_factor",
+    "turnover",
+}
 
 
 class AlphaSelector:
@@ -23,9 +70,10 @@ class AlphaSelector:
     def suggest_indicators(
         self,
         candidates: Optional[List[Dict]] = None,
-        metric: str = "sharpe_ratio",
+        metric: str = "ic",
         threshold: float = 0.0,
         top_k: int = 5,
+        selection_mode: str = FEATURE_SELECTION_MODE,
     ) -> List[Dict]:
         """
         Test a set of candidate indicators and return the best
@@ -34,23 +82,31 @@ class AlphaSelector:
         Args:
             candidates: List of indicator configs to test. If None, uses a default grid.
                         Format: [{"name": "RSI", "params": {"window": 14}}]
-            metric: Metric to optimize (sharpe_ratio, ic, annual_return).
-            threshold: Minimum value for the metric.
+            metric: Metric to optimize. Defaults to "ic".
+            threshold: Minimum acceptable value for higher-is-better metrics,
+                or maximum acceptable value for p-value metrics.
             top_k: Number of top indicators to return.
+            selection_mode: ``"feature"`` ranks indicators by continuous score
+                predictive power. ``"strategy"`` ranks indicators by discrete
+                trading-rule behavior and backtest metrics.
 
         Returns:
             List of indicator configurations ready for DataProcessor.
         """
+        validated_mode = validate_selection_mode(selection_mode)
+        self._validate_metric(metric, validated_mode)
+
         if candidates is None:
-            candidates = self._get_default_candidates()
+            candidates = self._get_default_candidates(validated_mode)
 
         if self.verbose:
-            console.print(f"[cyan]Evaluating {len(candidates)} candidate indicators...[/cyan]")
+            console.print(
+                f"[cyan]Evaluating {len(candidates)} candidate indicators " f"in {validated_mode} mode...[/cyan]"
+            )
 
         jobs = []
         for cand in candidates:
-            # Map indicator to strategy
-            strategy_config = self._map_indicator_to_strategy(cand)
+            strategy_config = self._get_strategy_config(cand, selection_mode=validated_mode)
             if not strategy_config:
                 if self.verbose:
                     console.print(f"[yellow]Skipping {cand['name']}: No strategy mapping found.[/yellow]")
@@ -62,85 +118,111 @@ class AlphaSelector:
                 indicator_params=cand.get("params", {}),
                 strategy_name=strategy_config["name"],
                 strategy_params=strategy_config["params"],
+                evaluation_mode=validated_mode,
                 id=f"job_{cand['name']}_{uuid.uuid4().hex[:4]}",
+                tags={"selection_mode": validated_mode},
             )
             jobs.append(job)
 
         results = self.runner.run_batch(jobs)
 
-        # Filter by threshold before passing to converter
-        above_threshold = [r for r in results if r.metrics.get(metric, -999) >= threshold]
+        # Filter by threshold before passing to converter.
+        above_threshold = [r for r in results if metric_threshold_passes(r.metrics.get(metric), threshold, metric)]
+        ranked_results = sort_alpha_results(above_threshold, metric=metric)
 
         if self.verbose:
-            console.print(f"[green]Found {len(above_threshold)} indicators above threshold {threshold}[/green]")
-            for r in sorted(above_threshold, key=lambda x: x.metrics.get(metric, -999), reverse=True)[:top_k]:
+            console.print(f"[green]Found {len(above_threshold)} indicators passing threshold {threshold}[/green]")
+            for r in ranked_results[:top_k]:
                 console.print(
                     f"  - {r.job.indicator_name} ({r.job.indicator_params}): {metric}={r.metrics.get(metric, 0):.4f}"
                 )
 
-        return results_to_pipeline_config(above_threshold, top_n=top_k, metric=metric)
+        return results_to_pipeline_config(ranked_results, top_n=top_k, metric=metric)
 
-    def _get_default_candidates(self) -> List[Dict]:
-        """Return a default grid covering all registered strategies."""
-        candidates = []
+    @classmethod
+    def suggest_for_universe(
+        cls,
+        raw_data: Dict[str, pd.DataFrame],
+        candidates: Optional[List[Dict]] = None,
+        metric: str = "ic",
+        threshold: float = 0.0,
+        top_k: int = 5,
+        verbose: bool = False,
+        selection_mode: str = FEATURE_SELECTION_MODE,
+    ) -> List[Dict]:
+        """
+        Select indicators across multiple symbols and return the
+        deduplicated union of suggested indicators.
 
-        # RSI — mean reversion
-        for w in [7, 14, 21]:
-            candidates.append({"name": "RSI", "params": {"window": w}})
+        Runs ``suggest_indicators`` on each symbol's raw OHLCV DataFrame
+        and deduplicates results by JSON-serialised indicator spec.  The
+        union approach ensures that any alpha-generating signal found for
+        any individual symbol is included in the shared feature set.
 
-        # SMA — trend following
-        for w in [20, 50, 200]:
-            candidates.append({"name": "SMA", "params": {"window": w}})
+        Args:
+            raw_data: Mapping of ``{symbol: ohlcv_df}`` (raw, unprocessed).
+            candidates: Candidate indicator configs to test. If None, uses the default grid.
+            metric: Scoring metric (e.g. ``"ic"``).
+            threshold: Minimum acceptable value for higher-is-better metrics,
+                or maximum acceptable value for p-value metrics.
+            top_k: Maximum indicators to pick *per symbol* before deduplication.
+            verbose: Whether to print per-symbol progress.
+            selection_mode: ``"feature"`` or ``"strategy"``.
 
-        # EMA — trend following (faster response than SMA)
-        for w in [12, 26, 50]:
-            candidates.append({"name": "EMA", "params": {"window": w}})
+        Returns:
+            Deduplicated list of indicator spec dicts ready for ``DataProcessor``.
+        """
+        all_suggested: List[Dict] = []
+        for symbol, df in raw_data.items():
+            selector = cls(df, verbose=verbose)
+            indicators = selector.suggest_indicators(
+                candidates=candidates,
+                metric=metric,
+                threshold=threshold,
+                top_k=top_k,
+                selection_mode=selection_mode,
+            )
+            if verbose:
+                console.print(f"  [cyan]{symbol}[/cyan]: {indicators}")
+            all_suggested.extend(indicators)
 
-        # MACD — crossover
-        candidates.append({"name": "MACD", "params": {"fast": 12, "slow": 26, "signal": 9}})
-        candidates.append({"name": "MACD", "params": {"fast": 5, "slow": 35, "signal": 5}})
+        # Deduplicate while preserving insertion order
+        seen: set = set()
+        unique_indicators: List[Dict] = []
+        for indicator in all_suggested:
+            key = json.dumps(indicator, sort_keys=True)
+            if key not in seen:
+                seen.add(key)
+                unique_indicators.append(indicator)
 
-        # Bollinger Bands — mean reversion at bands
-        candidates.append({"name": "BB", "params": {"window": 20, "num_std": 2.0}})
+        console.print(
+            f"[green]Alpha selection: {len(unique_indicators)} unique indicators "
+            f"across {len(raw_data)} symbol(s).[/green]"
+        )
+        return unique_indicators
 
-        # ATR — volatility breakout
-        candidates.append({"name": "ATR", "params": {"window": 14}})
+    def _get_default_candidates(self, selection_mode: str = FEATURE_SELECTION_MODE) -> List[Dict]:
+        """Return a default grid covering all indicators that have a
+        strategy mapping in the research metadata."""
+        return get_research_default_candidates(selection_mode)
 
-        # CCI — mean reversion
-        candidates.append({"name": "CCI", "params": {"window": 20}})
+    def _get_strategy_config(self, indicator: Dict, selection_mode: str = FEATURE_SELECTION_MODE) -> Optional[Dict]:
+        """
+        Look up the strategy config for an indicator from research
+        metadata.
 
-        # Stochastic — mean reversion
-        candidates.append({"name": "STOCH", "params": {"k_window": 14, "d_window": 3}})
-
-        # OBV — volume trend
-        candidates.append({"name": "OBV", "params": {}})
-
-        # ADX — trend strength + direction
-        candidates.append({"name": "ADX", "params": {"window": 14}})
-
-        return candidates
-
-    def _map_indicator_to_strategy(self, indicator: Dict) -> Optional[Dict]:
-        """Map an indicator config to a suitable testing strategy."""
+        Returns None if no mapping exists for the mode.
+        """
         name = indicator.get("name", "").upper()
+        return get_research_strategy_config(name, selection_mode=selection_mode)
 
-        if name == "RSI":
-            return {"name": "mean_reversion", "params": {"oversold": 30, "overbought": 70}}
-        elif name in ("SMA", "EMA"):
-            return {"name": "trend_following", "params": {}}
-        elif name == "MACD":
-            return {"name": "macd_crossover", "params": {}}
-        elif name == "BB":
-            return {"name": "bollinger_bands", "params": {}}
-        elif name == "ATR":
-            return {"name": "volatility_breakout", "params": {}}
-        elif name == "CCI":
-            return {"name": "cci_reversal", "params": {}}
-        elif name == "STOCH":
-            return {"name": "stochastic", "params": {}}
-        elif name == "OBV":
-            return {"name": "obv_trend", "params": {}}
-        elif name == "ADX":
-            return {"name": "adx_trend", "params": {}}
-
-        return None
+    @staticmethod
+    def _validate_metric(metric: str, selection_mode: str) -> None:
+        """Reject metrics that do not make sense for the requested
+        mode."""
+        allowed_metrics = FEATURE_MODE_METRICS if selection_mode == FEATURE_SELECTION_MODE else STRATEGY_MODE_METRICS
+        if metric not in allowed_metrics:
+            raise ValueError(
+                f"Metric '{metric}' is not supported for selection_mode='{selection_mode}'. "
+                f"Supported metrics: {sorted(allowed_metrics)}"
+            )

--- a/src/quantrl_lab/data/README.md
+++ b/src/quantrl_lab/data/README.md
@@ -1,0 +1,99 @@
+# Data Module
+
+The `quantrl_lab.data` package covers the full data path from provider access to model-ready feature matrices.
+It includes source loaders, capability-aware source registration, technical indicators, composable processing,
+dataset partitioning, and shared utilities for request handling and dataframe normalization.
+
+## Package Structure
+
+### Core Entry Points
+- **`source_registry.py`**: `DataSourceRegistry` for discovering and instantiating configured data sources.
+- **`interface.py`**: source capability contracts and feature declarations.
+- **`exceptions.py`**: typed data-source and validation exceptions.
+- **`config.py`**: shared defaults and data-specific configuration constants.
+
+### Data Sources
+- **`sources/`**: provider loaders for Alpaca, YFinance, Alpha Vantage, and FMP.
+- Capability metadata is explicit per loader, so registry filtering does not rely on runtime guessing.
+- Request wrappers in `utils/request_utils.py` and `utils/async_request_utils.py` normalize provider failures into
+  typed errors such as `AuthenticationError`, `RateLimitError`, and `APIConnectionError`.
+
+### Feature Engineering
+- **`indicators/`**: indicator registry plus built-in OHLCV indicators.
+- **`processing/`**: `DataProcessor`, `DataPipeline`, typed pipeline config objects, metadata tracking,
+  and pipeline steps for indicators, sentiment, analyst data, market context, cleanup, and cross-sectional features.
+- **`partitioning/`**: ratio- and date-based splitters for train / validation / test workflows.
+
+### Utilities
+- **`utils/`**: date parsing, date alignment, symbol handling, response validation, async helpers,
+  dataframe normalization, and request retry logic.
+
+## Recommended Usage
+
+### 1. Fetch raw market data
+
+```python
+from quantrl_lab.data import DataSourceRegistry
+
+registry = DataSourceRegistry()
+ohlcv_df = registry.get_historical_ohlcv_data(
+    symbols="AAPL",
+    start="2023-01-01",
+    end="2023-12-31",
+    timeframe="1d",
+)
+```
+
+### 2. Build a typed processing config
+
+```python
+from quantrl_lab.data import DataProcessor
+from quantrl_lab.data.processing import ProcessingPipelineConfig, SplitConfig
+
+processor = DataProcessor(ohlcv_data=ohlcv_df)
+
+pipeline_config = ProcessingPipelineConfig(
+    indicators=["SMA", {"RSI": {"window": 14}}, "MACD"],
+    split=SplitConfig(splits={"train": 0.7, "test": 0.3}),
+    verbose=False,
+)
+
+split_data, metadata = processor.data_processing_pipeline(pipeline_config=pipeline_config)
+```
+
+### 3. Use alpha research outside the pipeline
+
+Alpha selection is no longer performed inside `DataProcessor`. The recommended pattern is:
+
+1. run alpha research on raw data
+2. inspect or filter the suggested indicators
+3. pass those indicators into `ProcessingPipelineConfig` or `DataProcessor`
+
+```python
+from quantrl_lab.alpha_research import build_processing_config_from_alpha_selection
+from quantrl_lab.data import DataProcessor
+
+processor = DataProcessor(ohlcv_data=ohlcv_df)
+pipeline_config, selection_meta = build_processing_config_from_alpha_selection(
+    raw_data=ohlcv_df,
+    alpha_selection_config={"metric": "ic", "top_k": 5, "selection_mode": "feature"},
+    split_config={"train": 0.7, "test": 0.3},
+)
+
+split_data, metadata = processor.data_processing_pipeline(pipeline_config=pipeline_config)
+```
+
+## Key Behaviors
+
+- `DataProcessor` keeps the pipeline assembly high-level, but `build_pipeline()` lets you inspect the exact steps first.
+- Optional enrichment data such as analyst estimates and market context is treated as optional features rather than
+  forcing global row drops.
+- Split outputs preserve `Symbol` by default for panel workflows when that identity is still needed downstream.
+- `alpha_selection_config` on `DataProcessor` is deprecated and rejected; use `quantrl_lab.alpha_research.integration`
+  helpers instead.
+- Ratio splitting preserves all rows and requires the configured ratios to sum to `1.0`.
+
+## Related READMEs
+
+- [processing/README.md](./processing/README.md): pipeline assembly, steps, configs, and metadata
+- [indicators/README.md](./indicators/README.md): built-in technical indicator coverage and rationale

--- a/src/quantrl_lab/data/processing/README.md
+++ b/src/quantrl_lab/data/processing/README.md
@@ -44,6 +44,26 @@ processed_data, metadata = processor.data_processing_pipeline(
 
 Steps are added conditionally — sentiment enrichment only runs if `news_data` is provided, analyst estimates only if `analyst_grades`/`analyst_ratings` are provided, etc.
 
+For a more explicit assembly flow, use the typed config objects plus `build_pipeline()`:
+
+```python
+from quantrl_lab.data.processing import (
+    CrossSectionalConfig,
+    ProcessingPipelineConfig,
+    SplitConfig,
+)
+
+pipeline_config = ProcessingPipelineConfig(
+    indicators=["SMA", "RSI"],
+    cross_sectional=CrossSectionalConfig(columns=["Close"], methods=["rank"]),
+    split=SplitConfig(splits={"train": 0.7, "test": 0.3}),
+)
+
+pipeline = processor.build_pipeline(pipeline_config=pipeline_config)
+print(pipeline.describe())
+processed_data, metadata = processor.data_processing_pipeline(pipeline_config=pipeline_config)
+```
+
 ### Low-Level Builder API (Custom Workflows)
 
 For full control, construct a `DataPipeline` manually and chain steps using the builder pattern:
@@ -130,7 +150,7 @@ from quantrl_lab.data.processing.steps import (
 
 # 1. Ask alpha research for suggestions (outside the pipeline)
 selector = AlphaSelector(raw_df, verbose=True)
-suggested = selector.suggest_indicators(metric="sharpe_ratio", top_k=5)
+suggested = selector.suggest_indicators(metric="sharpe_ratio", top_k=5, selection_mode="strategy")
 # Returns e.g.: [{"RSI": {"window": 14}}, {"SMA": {"window": 50}}]
 
 # 2. User decision — inspect, filter, or mix with manual picks
@@ -159,7 +179,8 @@ When using the high-level API, steps are added in this order:
 3. `MarketContextStep` — only if sector/industry data is provided
 4. `SentimentEnrichmentStep` — only if `news_data` is provided
 5. `NumericConversionStep` — always added
-6. `ColumnCleanupStep` — always added
+6. `CrossSectionalStep` — only if cross-sectional config is provided
+7. `ColumnCleanupStep` — always added
 
 After pipeline execution, NaN rows are dropped (indicator warm-up periods), and data is optionally split.
 

--- a/src/quantrl_lab/data/processing/__init__.py
+++ b/src/quantrl_lab/data/processing/__init__.py
@@ -5,6 +5,22 @@ This package contains processors and mappings for transforming raw
 market data.
 """
 
+from .metadata import ProcessingMetadata
+from .pipeline import DataPipeline
+from .pipeline_config import (
+    CleanupConfig,
+    CrossSectionalConfig,
+    ProcessingPipelineConfig,
+    SplitConfig,
+)
 from .processor import DataProcessor
 
-__all__ = ["DataProcessor"]
+__all__ = [
+    "CleanupConfig",
+    "CrossSectionalConfig",
+    "DataPipeline",
+    "DataProcessor",
+    "ProcessingMetadata",
+    "ProcessingPipelineConfig",
+    "SplitConfig",
+]

--- a/src/quantrl_lab/data/processing/features/technical.py
+++ b/src/quantrl_lab/data/processing/features/technical.py
@@ -1,6 +1,8 @@
 """Technical feature generator."""
 
-from typing import Dict, List, Union
+import itertools
+import warnings
+from typing import Any, Dict, List, Union
 
 import pandas as pd
 
@@ -20,7 +22,7 @@ class TechnicalFeatureGenerator:
         >>> enriched_df = generator.generate(ohlcv_df)
     """
 
-    def __init__(self, indicators: List[Union[str, Dict]]):
+    def __init__(self, indicators: List[Union[str, Dict]], strict: bool = False):
         """
         Initialize TechnicalFeatureGenerator.
 
@@ -31,12 +33,90 @@ class TechnicalFeatureGenerator:
                     - ["SMA", "RSI"]
                     - [{"SMA": {"window": 20}}, {"RSI": {"window": 14}}]
                     - ["SMA", {"MACD": {"fast": 12, "slow": 26}}]
+            strict (bool): If True, fail fast when an indicator is unknown or
+                cannot be applied.
         """
         if not indicators:
             raise ValueError("indicators list cannot be empty")
 
         self.indicators = indicators
+        self.strict = strict
         self.registry = IndicatorRegistry
+        self._last_run_report: Dict[str, Any] = {}
+        self._seen_report_keys: set[str] = set()
+
+    def _reset_run_report(self) -> None:
+        """Initialize per-run indicator execution metadata."""
+        self._last_run_report = {
+            "requested": self.indicators.copy(),
+            "applied": [],
+            "skipped": [],
+            "failed": [],
+            "strict": self.strict,
+        }
+        self._seen_report_keys = set()
+
+    def _report_once(
+        self, bucket: str, indicator_config: Union[str, Dict], indicator_name: str, **details: Any
+    ) -> None:
+        """Record a run event once even when panel data is processed per
+        symbol."""
+        key = (bucket, repr(indicator_config), repr(sorted(details.items())))
+        if repr(key) in self._seen_report_keys:
+            return
+
+        self._seen_report_keys.add(repr(key))
+        entry = {
+            "indicator": indicator_name,
+            "config": indicator_config,
+            **details,
+        }
+        self._last_run_report[bucket].append(entry)
+
+    def _record_applied(self, indicator_config: Union[str, Dict], indicator_name: str) -> None:
+        """Track successfully applied indicators once per run."""
+        key = ("applied", repr(indicator_config))
+        if repr(key) in self._seen_report_keys:
+            return
+
+        self._seen_report_keys.add(repr(key))
+        self._last_run_report["applied"].append(indicator_config)
+
+    def _handle_skipped(self, indicator_config: Union[str, Dict], indicator_name: str, reason: str) -> None:
+        """Handle unknown or malformed indicators according to
+        strictness."""
+        self._report_once("skipped", indicator_config, indicator_name, reason=reason)
+        message = f"Skipping indicator '{indicator_name}': {reason}"
+        if self.strict:
+            raise ValueError(message)
+        warnings.warn(message, UserWarning, stacklevel=3)
+
+    def _handle_failure(self, indicator_config: Union[str, Dict], indicator_name: str, error: Exception) -> None:
+        """Handle indicator execution failures according to
+        strictness."""
+        error_message = str(error)
+        self._report_once("failed", indicator_config, indicator_name, error=error_message)
+        message = f"Failed to apply indicator '{indicator_name}': {error_message}"
+        if self.strict:
+            raise ValueError(message) from error
+        warnings.warn(message, UserWarning, stacklevel=3)
+
+    @staticmethod
+    def _expand_parameter_sets(custom_params: Any) -> List[Dict[str, Any]]:
+        """Expand list/grid-style indicator params into concrete
+        dictionaries."""
+        if isinstance(custom_params, list):
+            return [param_set for param_set in custom_params if isinstance(param_set, dict)]
+
+        if isinstance(custom_params, dict) and any(isinstance(v, list) for v in custom_params.values()):
+            param_names = list(custom_params.keys())
+            param_values = [value if isinstance(value, list) else [value] for value in custom_params.values()]
+            return [dict(zip(param_names, combination)) for combination in itertools.product(*param_values)]
+
+        if isinstance(custom_params, dict):
+            return [custom_params]
+
+        return [{}]
 
     def _generate_single(self, data: pd.DataFrame, **kwargs) -> pd.DataFrame:
         """Internal method to generate indicators for a single asset."""
@@ -50,49 +130,26 @@ class TechnicalFeatureGenerator:
                 custom_params = kwargs.get(f"{indicator_name}_params", {})
             elif isinstance(indicator_config, dict):
                 if len(indicator_config) != 1:
+                    self._handle_skipped(indicator_config, "<invalid>", "indicator config must contain exactly one key")
                     continue
                 indicator_name = list(indicator_config.keys())[0]
                 custom_params = indicator_config[indicator_name]
             else:
+                self._handle_skipped(
+                    indicator_config, "<invalid>", "indicator config must be a string or single-key dict"
+                )
                 continue
 
             if indicator_name not in available_indicators:
-                import warnings
-
-                warnings.warn(
-                    f"Unknown indicator '{indicator_name}' — not registered in IndicatorRegistry. Skipping.",
-                    UserWarning,
-                    stacklevel=2,
-                )
+                self._handle_skipped(indicator_config, indicator_name, "not registered in IndicatorRegistry")
                 continue
 
             try:
-                if isinstance(custom_params, list):
-                    for param_set in custom_params:
-                        if isinstance(param_set, dict):
-                            result = self.registry.apply(indicator_name, result, **param_set)
-                elif isinstance(custom_params, dict) and any(isinstance(v, list) for v in custom_params.values()):
-                    import itertools
-
-                    param_names = list(custom_params.keys())
-                    param_values = list(custom_params.values())
-                    param_values = [v if isinstance(v, list) else [v] for v in param_values]
-
-                    for combination in itertools.product(*param_values):
-                        params_dict = dict(zip(param_names, combination))
-                        result = self.registry.apply(indicator_name, result, **params_dict)
-                elif isinstance(custom_params, dict):
-                    result = self.registry.apply(indicator_name, result, **custom_params)
-                else:
-                    result = self.registry.apply(indicator_name, result)
+                for params_dict in self._expand_parameter_sets(custom_params):
+                    result = self.registry.apply(indicator_name, result, **params_dict)
+                self._record_applied(indicator_config, indicator_name)
             except Exception as e:
-                import warnings
-
-                warnings.warn(
-                    f"Failed to apply indicator '{indicator_name}': {e}",
-                    UserWarning,
-                    stacklevel=2,
-                )
+                self._handle_failure(indicator_config, indicator_name, e)
                 continue
 
         return result
@@ -113,6 +170,8 @@ class TechnicalFeatureGenerator:
         Raises:
             ValueError: If data is empty or missing required columns.
         """
+        self._reset_run_report()
+
         if data.empty:
             raise ValueError("Input DataFrame is empty. Technical indicators cannot be added.")
 
@@ -150,4 +209,11 @@ class TechnicalFeatureGenerator:
         return {
             "type": "technical_indicators",
             "indicators": self.indicators.copy() if isinstance(self.indicators, list) else [self.indicators],
+            "strict": self.strict,
+            "last_run": {
+                "requested": self._last_run_report.get("requested", []).copy(),
+                "applied": self._last_run_report.get("applied", []).copy(),
+                "skipped": self._last_run_report.get("skipped", []).copy(),
+                "failed": self._last_run_report.get("failed", []).copy(),
+            },
         }

--- a/src/quantrl_lab/data/processing/metadata.py
+++ b/src/quantrl_lab/data/processing/metadata.py
@@ -12,7 +12,7 @@ The dependency graph is now:
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 
 @dataclass
@@ -52,6 +52,11 @@ class ProcessingMetadata:
     date_ranges: Dict[str, Dict[str, str]] = field(default_factory=dict)
     fillna_strategy: str = "neutral"
     technical_indicators: List[Union[str, Dict]] = field(default_factory=list)
+    requested_technical_indicators: List[Union[str, Dict]] = field(default_factory=list)
+    applied_technical_indicators: List[Union[str, Dict]] = field(default_factory=list)
+    skipped_technical_indicators: List[Dict[str, Any]] = field(default_factory=list)
+    failed_technical_indicators: List[Dict[str, Any]] = field(default_factory=list)
+    strict_indicators: bool = False
     cross_sectional_features: List[str] = field(default_factory=list)
     news_sentiment_applied: bool = False
     analyst_data_applied: bool = False
@@ -97,6 +102,11 @@ class ProcessingMetadata:
             "date_ranges": self.date_ranges,
             "fillna_strategy": self.fillna_strategy,
             "technical_indicators": self.technical_indicators,
+            "requested_technical_indicators": self.requested_technical_indicators,
+            "applied_technical_indicators": self.applied_technical_indicators,
+            "skipped_technical_indicators": self.skipped_technical_indicators,
+            "failed_technical_indicators": self.failed_technical_indicators,
+            "strict_indicators": self.strict_indicators,
             "cross_sectional_features": self.cross_sectional_features,
             "news_sentiment_applied": self.news_sentiment_applied,
             "analyst_data_applied": self.analyst_data_applied,

--- a/src/quantrl_lab/data/processing/pipeline.py
+++ b/src/quantrl_lab/data/processing/pipeline.py
@@ -6,7 +6,7 @@ transformations. Each step in the pipeline processes the DataFrame and
 updates metadata.
 """
 
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 import pandas as pd
 from loguru import logger
@@ -112,11 +112,39 @@ class DataPipeline:
         """
         return self._steps.copy()
 
+    def get_step_names(self) -> List[str]:
+        """
+        Return the ordered human-readable step names in the pipeline.
+
+        Returns:
+            List[str]: Step names in execution order.
+        """
+        return [step.get_step_name() for step in self._steps]
+
+    def describe(self) -> Dict[str, object]:
+        """
+        Describe the assembled pipeline for debugging and experiment
+        logging.
+
+        Returns:
+            Dict[str, object]: Summary containing step count and ordered step metadata.
+        """
+        return {
+            "step_count": len(self._steps),
+            "steps": [
+                {
+                    "index": index + 1,
+                    "name": step.get_step_name(),
+                    "type": type(step).__name__,
+                }
+                for index, step in enumerate(self._steps)
+            ],
+        }
+
     def __len__(self) -> int:
         """Return number of steps in pipeline."""
         return len(self._steps)
 
     def __repr__(self) -> str:
         """Return string representation of pipeline."""
-        step_names = [step.get_step_name() for step in self._steps]
-        return f"DataPipeline({len(self._steps)} steps: {step_names})"
+        return f"DataPipeline({len(self._steps)} steps: {self.get_step_names()})"

--- a/src/quantrl_lab/data/processing/pipeline_config.py
+++ b/src/quantrl_lab/data/processing/pipeline_config.py
@@ -1,0 +1,49 @@
+"""Typed configuration objects for data-processing pipelines."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union
+
+IndicatorConfig = Union[str, Dict[str, Any]]
+
+
+@dataclass
+class CleanupConfig:
+    """Configuration for the cleanup step."""
+
+    columns_to_drop: Optional[List[str]] = None
+    keep_date: Optional[bool] = None
+    keep_symbol: Optional[bool] = None
+
+
+@dataclass
+class SplitConfig:
+    """Configuration for ratio- or date-based data splitting."""
+
+    splits: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return plain dictionary form for splitter compatibility."""
+        return dict(self.splits)
+
+
+@dataclass
+class CrossSectionalConfig:
+    """Configuration for cross-sectional feature generation."""
+
+    columns: List[str]
+    methods: List[str] = field(default_factory=lambda: ["zscore"])
+    date_column: Optional[str] = None
+
+
+@dataclass
+class ProcessingPipelineConfig:
+    """Top-level typed configuration for ``DataProcessor`` assembly."""
+
+    indicators: Optional[List[IndicatorConfig]] = None
+    fillna_strategy: str = "neutral"
+    split: Optional[SplitConfig] = None
+    cleanup: CleanupConfig = field(default_factory=CleanupConfig)
+    numeric_conversion_columns: Optional[List[str]] = None
+    strict_indicators: bool = False
+    verbose: bool = False
+    cross_sectional: Optional[CrossSectionalConfig] = None

--- a/src/quantrl_lab/data/processing/processor.py
+++ b/src/quantrl_lab/data/processing/processor.py
@@ -1,5 +1,7 @@
 import json
 import os
+import warnings
+from copy import deepcopy
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
@@ -18,6 +20,12 @@ from quantrl_lab.data.processing.features.technical import TechnicalFeatureGener
 # chain where all pipeline step files imported from processor.py.
 # Re-exported here for backward compatibility with existing user code.
 from quantrl_lab.data.processing.metadata import ProcessingMetadata  # noqa: F401
+from quantrl_lab.data.processing.pipeline_config import (
+    CleanupConfig,
+    CrossSectionalConfig,
+    ProcessingPipelineConfig,
+    SplitConfig,
+)
 
 # Import sentiment modules
 from quantrl_lab.data.processing.sentiment import (
@@ -107,6 +115,224 @@ class DataProcessor:
             # Default to HuggingFaceProvider if news data is present but no provider given
             self.sentiment_provider = HuggingFaceProvider()
 
+    def _has_multiple_symbols(self, df: pd.DataFrame) -> bool:
+        """Return True when the dataframe contains more than one
+        symbol."""
+        return "Symbol" in df.columns and df["Symbol"].dropna().nunique() > 1
+
+    @staticmethod
+    def _reject_alpha_selection_config(alpha_selection_config: Any) -> None:
+        """Reject deprecated in-processor alpha selection."""
+        if alpha_selection_config is None:
+            return
+
+        warnings.warn(
+            "`alpha_selection_config` on DataProcessor is deprecated and no longer performs alpha selection in the "
+            "data-processing layer. Use quantrl_lab.alpha_research.build_processing_config_from_alpha_selection(...) "
+            "or AlphaSelector explicitly, then pass indicators=... or pipeline_config=... to DataProcessor.",
+            FutureWarning,
+            stacklevel=3,
+        )
+        raise ValueError(
+            "DataProcessor no longer performs alpha selection. Use "
+            "quantrl_lab.alpha_research.build_processing_config_from_alpha_selection(...) "
+            "or AlphaSelector explicitly before calling DataProcessor."
+        )
+
+    @staticmethod
+    def _coerce_cleanup_config(cleanup_config: Optional[Union[CleanupConfig, Dict[str, Any]]]) -> CleanupConfig:
+        """Normalize cleanup config to the typed dataclass."""
+        if cleanup_config is None:
+            return CleanupConfig()
+        if isinstance(cleanup_config, CleanupConfig):
+            return cleanup_config
+        if isinstance(cleanup_config, dict):
+            return CleanupConfig(**cleanup_config)
+        raise TypeError("cleanup_config must be a dict or CleanupConfig.")
+
+    @staticmethod
+    def _coerce_cross_sectional_config(
+        cross_sectional_config: Optional[Union[CrossSectionalConfig, Dict[str, Any]]],
+    ) -> Optional[CrossSectionalConfig]:
+        """Normalize cross-sectional config to the typed dataclass."""
+        if cross_sectional_config is None:
+            return None
+        if isinstance(cross_sectional_config, CrossSectionalConfig):
+            return cross_sectional_config
+        if isinstance(cross_sectional_config, dict):
+            return CrossSectionalConfig(**cross_sectional_config)
+        raise TypeError("cross_sectional_config must be a dict or CrossSectionalConfig.")
+
+    @staticmethod
+    def _coerce_split_config(split_config: Optional[Union[SplitConfig, Dict[str, Any]]]) -> Optional[SplitConfig]:
+        """Normalize split config to the typed dataclass."""
+        if split_config is None:
+            return None
+        if isinstance(split_config, SplitConfig):
+            return split_config
+        if isinstance(split_config, dict):
+            return SplitConfig(splits=split_config)
+        raise TypeError("split_config must be a dict or SplitConfig.")
+
+    def _normalize_pipeline_config(
+        self,
+        *,
+        indicators: Optional[List[Union[str, Dict]]] = None,
+        alpha_selection_config: Optional[Any] = None,
+        fillna_strategy: str = "neutral",
+        split_config: Optional[Union[SplitConfig, Dict[str, Any]]] = None,
+        cross_sectional_config: Optional[Union[CrossSectionalConfig, Dict[str, Any]]] = None,
+        cleanup_config: Optional[Union[CleanupConfig, Dict[str, Any]]] = None,
+        numeric_conversion_columns: Optional[List[str]] = None,
+        strict_indicators: bool = False,
+        verbose: bool = False,
+        pipeline_config: Optional[ProcessingPipelineConfig] = None,
+        legacy_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> ProcessingPipelineConfig:
+        """Resolve explicit args, typed configs, and legacy kwargs into
+        one typed config."""
+        legacy_kwargs = dict(legacy_kwargs or {})
+        self._reject_alpha_selection_config(alpha_selection_config)
+
+        if pipeline_config is not None:
+            if not isinstance(pipeline_config, ProcessingPipelineConfig):
+                raise TypeError("pipeline_config must be a ProcessingPipelineConfig instance.")
+
+            if (
+                indicators is not None
+                or alpha_selection_config is not None
+                or fillna_strategy != "neutral"
+                or split_config is not None
+                or cross_sectional_config is not None
+                or cleanup_config is not None
+                or numeric_conversion_columns is not None
+                or strict_indicators
+                or verbose
+                or legacy_kwargs
+            ):
+                raise ValueError("Use either pipeline_config or individual pipeline arguments, not both.")
+            return deepcopy(pipeline_config)
+
+        cleanup = self._coerce_cleanup_config(cleanup_config)
+
+        if "columns_to_drop" in legacy_kwargs:
+            warnings.warn(
+                "`columns_to_drop` is deprecated; pass cleanup_config=CleanupConfig(columns_to_drop=...) instead.",
+                FutureWarning,
+                stacklevel=3,
+            )
+            if cleanup.columns_to_drop is not None:
+                raise ValueError("Specify columns_to_drop via either cleanup_config or legacy kwargs, not both.")
+            cleanup.columns_to_drop = legacy_kwargs.pop("columns_to_drop")
+
+        if "columns_to_convert" in legacy_kwargs:
+            warnings.warn(
+                "`columns_to_convert` is deprecated; pass numeric_conversion_columns=[...] instead.",
+                FutureWarning,
+                stacklevel=3,
+            )
+            if numeric_conversion_columns is not None:
+                raise ValueError(
+                    "Specify numeric conversion columns via either "
+                    "numeric_conversion_columns or legacy kwargs, not both."
+                )
+            numeric_conversion_columns = legacy_kwargs.pop("columns_to_convert")
+
+        if legacy_kwargs:
+            unexpected = ", ".join(sorted(legacy_kwargs))
+            raise TypeError(f"Unexpected keyword arguments: {unexpected}")
+
+        return ProcessingPipelineConfig(
+            indicators=deepcopy(indicators),
+            fillna_strategy=fillna_strategy,
+            split=self._coerce_split_config(split_config),
+            cleanup=cleanup,
+            numeric_conversion_columns=deepcopy(numeric_conversion_columns),
+            strict_indicators=strict_indicators,
+            verbose=verbose,
+            cross_sectional=self._coerce_cross_sectional_config(cross_sectional_config),
+        )
+
+    def _resolve_cleanup_behavior(self, pipeline_config: ProcessingPipelineConfig) -> Tuple[bool, bool]:
+        """Determine cleanup defaults based on split/panel
+        configuration."""
+        has_split = pipeline_config.split is not None
+        preserve_symbol_by_default = self._has_multiple_symbols(self.ohlcv_data) and (
+            has_split or pipeline_config.cross_sectional is not None
+        )
+
+        keep_date = pipeline_config.cleanup.keep_date if pipeline_config.cleanup.keep_date is not None else has_split
+        keep_symbol = (
+            pipeline_config.cleanup.keep_symbol
+            if pipeline_config.cleanup.keep_symbol is not None
+            else preserve_symbol_by_default
+        )
+        return keep_date, keep_symbol
+
+    def _assemble_pipeline(
+        self,
+        pipeline_config: ProcessingPipelineConfig,
+        resolved_indicators: Optional[List[Union[str, Dict]]],
+    ):
+        """Create a ``DataPipeline`` from the normalized
+        configuration."""
+        from quantrl_lab.data.processing.pipeline import DataPipeline
+        from quantrl_lab.data.processing.steps import (
+            AnalystEstimatesStep,
+            ColumnCleanupStep,
+            CrossSectionalStep,
+            MarketContextStep,
+            NumericConversionStep,
+            SentimentEnrichmentStep,
+            TechnicalIndicatorStep,
+        )
+
+        keep_date, keep_symbol = self._resolve_cleanup_behavior(pipeline_config)
+
+        pipeline = DataPipeline()
+        pipeline.add_step(
+            TechnicalIndicatorStep(indicators=resolved_indicators, strict=pipeline_config.strict_indicators)
+        )
+
+        if self.analyst_grades is not None or self.analyst_ratings is not None:
+            pipeline.add_step(AnalystEstimatesStep(grades_df=self.analyst_grades, ratings_df=self.analyst_ratings))
+
+        if self.sector_performance is not None or self.industry_performance is not None:
+            pipeline.add_step(
+                MarketContextStep(sector_perf_df=self.sector_performance, industry_perf_df=self.industry_performance)
+            )
+
+        if self.news_data is not None:
+            pipeline.add_step(
+                SentimentEnrichmentStep(
+                    news_data=self.news_data,
+                    provider=self.sentiment_provider,
+                    config=self.sentiment_config,
+                    fillna_strategy=pipeline_config.fillna_strategy,
+                )
+            )
+
+        pipeline.add_step(NumericConversionStep(columns=pipeline_config.numeric_conversion_columns))
+
+        if pipeline_config.cross_sectional is not None:
+            pipeline.add_step(
+                CrossSectionalStep(
+                    columns=pipeline_config.cross_sectional.columns,
+                    methods=pipeline_config.cross_sectional.methods,
+                    date_column=pipeline_config.cross_sectional.date_column,
+                )
+            )
+
+        pipeline.add_step(
+            ColumnCleanupStep(
+                columns_to_drop=pipeline_config.cleanup.columns_to_drop,
+                keep_date=keep_date,
+                keep_symbol=keep_symbol,
+            )
+        )
+
+        return pipeline
+
     def append_technical_indicators(
         self,
         df: pd.DataFrame,
@@ -131,7 +357,7 @@ class DataProcessor:
         if not indicators:
             return df.copy()
 
-        generator = TechnicalFeatureGenerator(indicators)
+        generator = TechnicalFeatureGenerator(indicators, strict=kwargs.pop("strict_indicators", False))
         return generator.generate(df, **kwargs)
 
     def append_news_sentiment_data(self, df: pd.DataFrame, fillna_strategy="neutral") -> pd.DataFrame:
@@ -158,7 +384,11 @@ class DataProcessor:
         return generator.generate(df)
 
     def drop_unwanted_columns(
-        self, df: pd.DataFrame, columns_to_drop: Optional[List[str]] = None, keep_date: bool = False
+        self,
+        df: pd.DataFrame,
+        columns_to_drop: Optional[List[str]] = None,
+        keep_date: bool = False,
+        keep_symbol: bool = False,
     ) -> pd.DataFrame:
         """
         Drop unwanted columns from the DataFrame.
@@ -168,12 +398,15 @@ class DataProcessor:
             columns_to_drop (Optional[List[str]], optional): List of column names to drop.
                 If None, will drop default columns ('Date', 'Timestamp', 'Symbol'). Defaults to None.
             keep_date (bool): If True, date-related columns will not be dropped.
+            keep_symbol (bool): If True, preserve ``Symbol`` under the default cleanup policy.
         Returns:
             pd.DataFrame: DataFrame with specified columns dropped.
         """
         from quantrl_lab.data.processing.steps import ColumnCleanupStep
 
-        return ColumnCleanupStep(columns_to_drop=columns_to_drop, keep_date=keep_date).process(df, ProcessingMetadata())
+        return ColumnCleanupStep(columns_to_drop=columns_to_drop, keep_date=keep_date, keep_symbol=keep_symbol).process(
+            df, ProcessingMetadata()
+        )
 
     def convert_columns_to_numeric(self, df: pd.DataFrame, columns: Optional[List[str]] = None) -> pd.DataFrame:
         """
@@ -191,12 +424,55 @@ class DataProcessor:
 
         return NumericConversionStep(columns=columns).process(df, ProcessingMetadata())
 
+    def build_pipeline(
+        self,
+        indicators: Optional[List[Union[str, Dict]]] = None,
+        alpha_selection_config: Optional[Any] = None,
+        fillna_strategy: str = "neutral",
+        split_config: Optional[Union[SplitConfig, Dict[str, Any]]] = None,
+        *,
+        cross_sectional_config: Optional[Union[CrossSectionalConfig, Dict[str, Any]]] = None,
+        cleanup_config: Optional[Union[CleanupConfig, Dict[str, Any]]] = None,
+        numeric_conversion_columns: Optional[List[str]] = None,
+        strict_indicators: bool = False,
+        verbose: bool = False,
+        pipeline_config: Optional[ProcessingPipelineConfig] = None,
+        **kwargs: Any,
+    ):
+        """
+        Assemble and return a ``DataPipeline`` without executing it.
+
+        This is useful for downstream inspection, logging, and custom
+        execution flows.
+        """
+        normalized_config = self._normalize_pipeline_config(
+            indicators=indicators,
+            alpha_selection_config=alpha_selection_config,
+            fillna_strategy=fillna_strategy,
+            split_config=split_config,
+            cross_sectional_config=cross_sectional_config,
+            cleanup_config=cleanup_config,
+            numeric_conversion_columns=numeric_conversion_columns,
+            strict_indicators=strict_indicators,
+            verbose=verbose,
+            pipeline_config=pipeline_config,
+            legacy_kwargs=kwargs,
+        )
+        return self._assemble_pipeline(normalized_config, deepcopy(normalized_config.indicators))
+
     def data_processing_pipeline(
         self,
         indicators: Optional[List[Union[str, Dict]]] = None,
-        alpha_selection_config: Optional[Dict[str, Any]] = None,
+        alpha_selection_config: Optional[Any] = None,
         fillna_strategy: str = "neutral",
-        split_config: Optional[Dict] = None,
+        split_config: Optional[Union[SplitConfig, Dict[str, Any]]] = None,
+        *,
+        cross_sectional_config: Optional[Union[CrossSectionalConfig, Dict[str, Any]]] = None,
+        cleanup_config: Optional[Union[CleanupConfig, Dict[str, Any]]] = None,
+        numeric_conversion_columns: Optional[List[str]] = None,
+        strict_indicators: bool = False,
+        verbose: bool = False,
+        pipeline_config: Optional[ProcessingPipelineConfig] = None,
         **kwargs: Any,
     ) -> Tuple[Union[pd.DataFrame, Dict[str, pd.DataFrame]], Dict]:
         """
@@ -212,10 +488,10 @@ class DataProcessor:
                 - String format: ["SMA", "RSI"]
                 - Dict format: [{"SMA": {"window": 20}}, {"RSI": {"window": 14}}]
                 Defaults to None (no indicators).
-            alpha_selection_config (Optional[Dict], optional):
-                Configuration for dynamic alpha selection. If provided, the pipeline
-                will automatically select and apply the best indicators.
-                Keys: "metric" (default "ic"), "threshold", "top_k", "candidates".
+            alpha_selection_config: Deprecated. Alpha selection is no longer
+                performed inside ``DataProcessor``. Use
+                ``quantrl_lab.alpha_research.build_processing_config_from_alpha_selection(...)``
+                or ``AlphaSelector`` explicitly.
             fillna_strategy (str, optional): Strategy for handling missing sentiment scores.
                 Options: "neutral" (fill with 0.0) or "fill_forward" (forward fill).
                 Defaults to "neutral".
@@ -223,9 +499,19 @@ class DataProcessor:
                 If None, returns a single DataFrame. Otherwise, returns dict of DataFrames.
                 Ratio-based: {'train': 0.7, 'test': 0.3}
                 Date-based: {'train': ('2020-01-01', '2021-12-31'), 'test': ('2022-01-01', '2022-12-31')}
-            **kwargs: Additional arguments:
-                - columns_to_drop: List of columns to drop (overrides default)
-                - columns_to_convert: List of columns to convert to numeric
+            cross_sectional_config: Optional configuration for cross-sectional
+                feature generation on panel data.
+            cleanup_config: Optional typed cleanup config replacing ad hoc
+                column-drop kwargs.
+            numeric_conversion_columns: Optional explicit columns to coerce to
+                numeric before cleanup.
+            strict_indicators: If True, fail fast when indicator application
+                encounters unknown names or runtime errors.
+            verbose: Enable additional pipeline logging.
+            pipeline_config: Optional typed config object. Cannot be mixed with
+                the other pipeline arguments.
+            **kwargs: Deprecated compatibility kwargs such as
+                ``columns_to_drop`` and ``columns_to_convert``.
 
         Returns:
             Tuple[Union[pd.DataFrame, Dict[str, pd.DataFrame]], Dict]: A tuple containing:
@@ -233,71 +519,24 @@ class DataProcessor:
                 - Dictionary of DataFrames if split_config is provided (keys: split names)
                 - Metadata dictionary with processing information
         """
-        from quantrl_lab.data.processing.pipeline import DataPipeline
-        from quantrl_lab.data.processing.steps import (
-            AnalystEstimatesStep,
-            ColumnCleanupStep,
-            MarketContextStep,
-            NumericConversionStep,
-            SentimentEnrichmentStep,
-            TechnicalIndicatorStep,
+        from quantrl_lab.data.processing.steps import ColumnCleanupStep
+
+        normalized_config = self._normalize_pipeline_config(
+            indicators=indicators,
+            alpha_selection_config=alpha_selection_config,
+            fillna_strategy=fillna_strategy,
+            split_config=split_config,
+            cross_sectional_config=cross_sectional_config,
+            cleanup_config=cleanup_config,
+            numeric_conversion_columns=numeric_conversion_columns,
+            strict_indicators=strict_indicators,
+            verbose=verbose,
+            pipeline_config=pipeline_config,
+            legacy_kwargs=kwargs,
         )
-
-        # Resolve indicators — auto-select via AlphaSelector when requested
-        if alpha_selection_config is not None and indicators is None:
-            from quantrl_lab.alpha_research.selector import AlphaSelector
-
-            selector = AlphaSelector(self.ohlcv_data, verbose=kwargs.get("verbose", False))
-            indicators = selector.suggest_indicators(
-                candidates=alpha_selection_config.get("candidates"),
-                metric=alpha_selection_config.get("metric", "ic"),
-                threshold=alpha_selection_config.get("threshold", 0.0),
-                top_k=alpha_selection_config.get("top_k", 5),
-            )
-
-        # Build pipeline
-        pipeline = DataPipeline()
-
-        # 1. Technical Indicators
-        pipeline.add_step(TechnicalIndicatorStep(indicators=indicators))
-
-        # 2. Analyst Estimates
-        if self.analyst_grades is not None or self.analyst_ratings is not None:
-            pipeline.add_step(AnalystEstimatesStep(grades_df=self.analyst_grades, ratings_df=self.analyst_ratings))
-
-        # 3. Market Context
-        if self.sector_performance is not None or self.industry_performance is not None:
-            pipeline.add_step(
-                MarketContextStep(sector_perf_df=self.sector_performance, industry_perf_df=self.industry_performance)
-            )
-
-        # 4. Sentiment Enrichment (only if news data available)
-        if self.news_data is not None:
-            pipeline.add_step(
-                SentimentEnrichmentStep(
-                    news_data=self.news_data,
-                    provider=self.sentiment_provider,
-                    config=self.sentiment_config,
-                    fillna_strategy=fillna_strategy,
-                )
-            )
-
-        # 5. Numeric Conversion
-        # Convert specified columns to numeric
-        columns_to_convert = kwargs.get("columns_to_convert", None)
-        pipeline.add_step(NumericConversionStep(columns=columns_to_convert))
-
-        # 6. Column Cleanup
-        # If columns_to_drop is passed, use it; otherwise rely on defaults in step
-        # Note: We keep date columns if splitting is required later
-        columns_to_drop = kwargs.get("columns_to_drop", None)
-        # If splitting, we MUST keep date columns for the split operation
-        # If not splitting, the pipeline step handles default date dropping unless overridden
-        keep_date = split_config is not None
-
-        # Configure Cleanup Step
-        cleanup_step = ColumnCleanupStep(columns_to_drop=columns_to_drop, keep_date=keep_date)
-        pipeline.add_step(cleanup_step)
+        resolved_split_config = normalized_config.split.to_dict() if normalized_config.split is not None else None
+        pipeline = self._assemble_pipeline(normalized_config, deepcopy(normalized_config.indicators))
+        _, keep_symbol = self._resolve_cleanup_behavior(normalized_config)
 
         # Execute Pipeline
         # We pass symbol for metadata tracking if available
@@ -313,13 +552,9 @@ class DataProcessor:
             metadata_obj.analyst_data_applied = True
         if self.sector_performance is not None or self.industry_performance is not None:
             metadata_obj.market_context_applied = True
-        if alpha_selection_config is not None:
-            metadata_obj.alpha_selection_config = alpha_selection_config
-
         # Handle Data Splitting (Post-Processing)
         # Debug: Check for columns with all NaN values before dropna
-        verbose = kwargs.get("verbose", False)
-        if verbose:
+        if normalized_config.verbose:
             null_counts = processed_data.isnull().sum()
             all_null_cols = null_counts[null_counts == len(processed_data)]
             if not all_null_cols.empty:
@@ -333,7 +568,7 @@ class DataProcessor:
         processed_data = processed_data.dropna(subset=required_columns or None)
         dropped_count = initial_len - len(processed_data)
 
-        if verbose:
+        if normalized_config.verbose:
             if dropped_count > 0:
                 logger.info(
                     "Dropped {count} rows containing NaNs in required columns: {columns}",
@@ -343,24 +578,24 @@ class DataProcessor:
             else:
                 logger.info("No rows dropped (data is clean)")
 
-        if verbose:
+        if normalized_config.verbose:
             logger.info("After dropna: {rows} rows", rows=len(processed_data))
 
-        if split_config:
-            split_data, split_metadata = self._split_data(processed_data, split_config)
+        if resolved_split_config:
+            split_data, split_metadata = self._split_data(processed_data, resolved_split_config)
 
             # Merge split metadata into pipeline metadata
             metadata_obj.date_ranges = split_metadata["date_ranges"]
             metadata_obj.final_shapes = split_metadata["final_shapes"]
 
-            # Drop date column after splitting if it wasn't supposed to be kept
+            # Re-run cleanup after splitting so date columns can be removed while
+            # preserving caller intent and panel identity defaults.
             for key in split_data:
-                # Re-run cleanup to drop date columns now that splitting is done
-                # unless user explicitly asked to keep them via columns_to_drop logic?
-                # For safety, we replicate old behavior: drop defaults
-                split_data[key] = self.drop_unwanted_columns(
-                    split_data[key], [config.DEFAULT_DATE_COLUMN, "Timestamp", "Symbol"]
-                )
+                split_data[key] = ColumnCleanupStep(
+                    columns_to_drop=normalized_config.cleanup.columns_to_drop,
+                    keep_date=False,
+                    keep_symbol=keep_symbol,
+                ).process(split_data[key], metadata_obj)
 
             return split_data, metadata_obj.to_dict()
         else:
@@ -373,10 +608,6 @@ class DataProcessor:
                     "end": dates.max().strftime("%Y-%m-%d"),
                 }
             metadata_obj.final_shapes["full_data"] = processed_data.shape
-
-            # If we didn't split, we might still need to drop the date column if it was kept
-            if not keep_date:
-                pass
 
             return processed_data, metadata_obj.to_dict()
 

--- a/src/quantrl_lab/data/processing/steps/cleaning/cleanup.py
+++ b/src/quantrl_lab/data/processing/steps/cleaning/cleanup.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 import pandas as pd
 
 from quantrl_lab.data.config import config
-from quantrl_lab.data.processing.processor import ProcessingMetadata
+from quantrl_lab.data.processing.metadata import ProcessingMetadata
 
 
 class ColumnCleanupStep:
@@ -20,14 +20,22 @@ class ColumnCleanupStep:
         >>> result = step.process(df, metadata)
     """
 
-    def __init__(self, columns_to_drop: Optional[List[str]] = None, keep_date: bool = False):
+    def __init__(
+        self,
+        columns_to_drop: Optional[List[str]] = None,
+        keep_date: bool = False,
+        keep_symbol: bool = False,
+    ):
         """
         Initialize column cleanup step.
 
         Args:
             columns_to_drop: List of columns to drop. If None, drops default columns.
             keep_date: If True, preserve date columns even if in columns_to_drop.
+            keep_symbol: If True, preserve ``Symbol`` when using the default
+                cleanup policy. Explicit caller-provided drop lists still win.
         """
+        self._using_default_columns = columns_to_drop is None
         if columns_to_drop is None:
             self.columns_to_drop = [config.DEFAULT_DATE_COLUMN, "Timestamp", "Symbol"]
         elif not isinstance(columns_to_drop, list):
@@ -38,6 +46,7 @@ class ColumnCleanupStep:
             self.columns_to_drop = columns_to_drop
 
         self.keep_date = keep_date
+        self.keep_symbol = keep_symbol
 
     def process(self, data: pd.DataFrame, metadata: ProcessingMetadata) -> pd.DataFrame:
         """
@@ -54,10 +63,14 @@ class ColumnCleanupStep:
 
         if self.keep_date:
             columns_to_drop = [col for col in columns_to_drop if col not in config.DATE_COLUMNS]
+        if self.keep_symbol and self._using_default_columns:
+            columns_to_drop = [col for col in columns_to_drop if col != "Symbol"]
 
         # Track actually dropped columns
         actually_dropped = [col for col in columns_to_drop if col in data.columns]
-        metadata.columns_dropped.extend(actually_dropped)
+        for column in actually_dropped:
+            if column not in metadata.columns_dropped:
+                metadata.columns_dropped.append(column)
 
         return data.drop(columns=columns_to_drop, errors="ignore")
 

--- a/src/quantrl_lab/data/processing/steps/cleaning/conversion.py
+++ b/src/quantrl_lab/data/processing/steps/cleaning/conversion.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 import pandas as pd
 
 from quantrl_lab.data.config import config
-from quantrl_lab.data.processing.processor import ProcessingMetadata
+from quantrl_lab.data.processing.metadata import ProcessingMetadata
 
 
 class NumericConversionStep:
@@ -52,6 +52,8 @@ class NumericConversionStep:
             columns_to_convert = []
             for col in df.columns:
                 if df[col].dtype == "object":
+                    if col == "Symbol":
+                        continue
                     if col in config.DATE_COLUMNS or col.lower() in [c.lower() for c in config.DATE_COLUMNS]:
                         continue
 

--- a/src/quantrl_lab/data/processing/steps/features/cross_sectional.py
+++ b/src/quantrl_lab/data/processing/steps/features/cross_sectional.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 import pandas as pd
 from loguru import logger
 
+from quantrl_lab.data.config import config
 from quantrl_lab.data.processing.metadata import ProcessingMetadata
 
 
@@ -26,7 +27,7 @@ class CrossSectionalStep:
         >>> result = step.process(df, metadata)
     """
 
-    def __init__(self, columns: List[str], methods: Optional[List[str]] = None):
+    def __init__(self, columns: List[str], methods: Optional[List[str]] = None, date_column: Optional[str] = None):
         """
         Initialize cross-sectional step.
 
@@ -34,15 +35,40 @@ class CrossSectionalStep:
             columns: List of feature column names to process (e.g., ["RSI_14", "Volume"]).
             methods: List of cross-sectional methods to apply.
                      Supported: "zscore", "rank", "mean_centered".
+            date_column: Optional explicit date column to group by. If not
+                provided, the step uses the first known date column or a
+                ``DatetimeIndex``.
         """
         self.columns = columns
         self.methods = methods if methods is not None else ["zscore"]
+        self.date_column = date_column
         self.supported_methods = {"zscore", "rank", "mean_centered"}
 
         # Validate methods
         for m in self.methods:
             if m not in self.supported_methods:
                 raise ValueError(f"Unsupported cross-sectional method: {m}. Use one of {self.supported_methods}")
+
+    def _resolve_grouping_key(self, data: pd.DataFrame) -> Optional[pd.Series]:
+        """Resolve the date-like grouping key for cross-sectional
+        transforms."""
+        if self.date_column is not None:
+            if self.date_column not in data.columns:
+                logger.warning(
+                    "CrossSectionalStep date_column '{column}' not found. Skipping.", column=self.date_column
+                )
+                return None
+            return pd.Series(pd.to_datetime(data[self.date_column], errors="coerce"), index=data.index)
+
+        for candidate in config.DATE_COLUMNS + ["Timestamp"]:
+            if candidate in data.columns:
+                return pd.Series(pd.to_datetime(data[candidate], errors="coerce"), index=data.index)
+
+        if pd.api.types.is_datetime64_any_dtype(data.index):
+            return pd.Series(pd.to_datetime(data.index), index=data.index)
+
+        logger.warning("CrossSectionalStep requires a date column or DatetimeIndex. Skipping.")
+        return None
 
     def process(self, data: pd.DataFrame, metadata: ProcessingMetadata) -> pd.DataFrame:
         """
@@ -68,9 +94,11 @@ class CrossSectionalStep:
 
         result = data.copy()
 
-        # We group by the index (which is assumed to be Date/Timestamp)
-        # to calculate cross-sectional stats across all symbols on that day.
-        grouped = result.groupby(level=0)
+        grouping_key = self._resolve_grouping_key(result)
+        if grouping_key is None:
+            return data
+
+        grouped = result.groupby(grouping_key)
 
         for col in self.columns:
             if col not in result.columns:

--- a/src/quantrl_lab/data/processing/steps/features/technical.py
+++ b/src/quantrl_lab/data/processing/steps/features/technical.py
@@ -22,15 +22,17 @@ class TechnicalIndicatorStep:
         >>> result = step.process(df, metadata)
     """
 
-    def __init__(self, indicators: Optional[List[Union[str, Dict]]] = None):
+    def __init__(self, indicators: Optional[List[Union[str, Dict]]] = None, strict: bool = False):
         """
         Initialize technical indicator step.
 
         Args:
             indicators: List of indicators to apply. Can be strings ("SMA")
                 or dicts ({"SMA": {"window": 20}}).
+            strict: If True, fail fast on unknown or broken indicators.
         """
         self.indicators = indicators or []
+        self.strict = strict
 
     def process(self, data: pd.DataFrame, metadata: ProcessingMetadata) -> pd.DataFrame:
         """
@@ -49,12 +51,25 @@ class TechnicalIndicatorStep:
         if not self.indicators:
             return data.copy()
 
-        generator = TechnicalFeatureGenerator(self.indicators)
+        generator = TechnicalFeatureGenerator(self.indicators, strict=self.strict)
         result = generator.generate(data)
+        generator_metadata = generator.get_metadata()["last_run"]
 
         metadata.technical_indicators = self.indicators
+        metadata.requested_technical_indicators = generator_metadata["requested"]
+        metadata.applied_technical_indicators = generator_metadata["applied"]
+        metadata.skipped_technical_indicators = generator_metadata["skipped"]
+        metadata.failed_technical_indicators = generator_metadata["failed"]
+        metadata.strict_indicators = self.strict
         metadata.add_required_columns([col for col in result.columns if col not in data.columns])
-        logger.debug("Applied technical indicators: {indicators}", indicators=self.indicators)
+        logger.debug(
+            "Applied technical indicators: requested={requested}, applied={applied}, "
+            "skipped={skipped}, failed={failed}",
+            requested=metadata.requested_technical_indicators,
+            applied=metadata.applied_technical_indicators,
+            skipped=metadata.skipped_technical_indicators,
+            failed=metadata.failed_technical_indicators,
+        )
 
         return result
 

--- a/tests/alpha_research/test_alpha_research.py
+++ b/tests/alpha_research/test_alpha_research.py
@@ -25,6 +25,10 @@ from quantrl_lab.alpha_research.alpha_strategies import (
 from quantrl_lab.alpha_research.analysis import RobustnessTester
 from quantrl_lab.alpha_research.base import SignalType
 from quantrl_lab.alpha_research.ensemble import AlphaEnsemble
+from quantrl_lab.alpha_research.indicator_research import (
+    FEATURE_SELECTION_MODE,
+    INDICATOR_RESEARCH_METADATA,
+)
 from quantrl_lab.alpha_research.models import AlphaJob, AlphaResult
 from quantrl_lab.alpha_research.registry import VectorizedStrategyRegistry
 from quantrl_lab.alpha_research.runner import AlphaRunner
@@ -396,6 +400,29 @@ class TestAlphaRunner:
         assert result.job == sample_alpha_job
         # Result should be either completed or failed
         assert result.status in ["completed", "failed"]
+
+    def test_run_feature_mode_job_returns_scores(self, sample_alpha_job):
+        """Feature mode should return score-based metrics without an
+        equity curve."""
+        runner = AlphaRunner(verbose=False)
+        feature_job = AlphaJob(
+            data=sample_alpha_job.data,
+            indicator_name=sample_alpha_job.indicator_name,
+            strategy_name=sample_alpha_job.strategy_name,
+            indicator_params=sample_alpha_job.indicator_params,
+            strategy_params=sample_alpha_job.strategy_params,
+            evaluation_mode=FEATURE_SELECTION_MODE,
+        )
+
+        result = runner.run_job(feature_job)
+
+        assert result.status == "completed"
+        assert result.equity_curve is None
+        assert result.signals is None
+        assert result.scores is not None
+        assert "feature_ic" in result.metrics
+        assert "ic" in result.metrics
+        assert "sharpe_ratio" not in result.metrics
 
     def test_run_batch(self, sample_data_with_indicators):
         """Test running a batch of jobs."""
@@ -982,20 +1009,33 @@ class TestColumnCaseNormalisation:
     AlphaRunner."""
 
     def test_lowercase_columns_auto_renamed(self, sample_ohlcv_data):
-        """Lowercase OHLCV columns are silently renamed to title-
-        case."""
+        """
+        Lowercase OHLCV columns are silently renamed to title-case.
+
+        _validate_data returns a renamed copy instead of mutating the
+        input in-place (fix for A-3), so we check the return value and
+        also verify the original DataFrame is NOT mutated.
+        """
         df = sample_ohlcv_data.rename(columns=str.lower)
+        original_cols = list(df.columns)
         runner = AlphaRunner(verbose=False)
-        runner._validate_data(df)  # should not raise
-        assert "Close" in df.columns
-        assert "close" not in df.columns
+        result = runner._validate_data(df)
+        # Returned DataFrame has normalised column names
+        assert "Close" in result.columns
+        assert "close" not in result.columns
+        # Original DataFrame is NOT mutated
+        assert list(df.columns) == original_cols
 
     def test_mixed_case_columns_auto_renamed(self, sample_ohlcv_data):
-        """Mixed-case columns (e.g., 'CLOSE') are also handled."""
+        """
+        Mixed-case columns (e.g., 'CLOSE') are also handled.
+
+        Checks the returned copy, not the original (fix for A-3).
+        """
         df = sample_ohlcv_data.rename(columns=lambda c: c.upper())
         runner = AlphaRunner(verbose=False)
-        runner._validate_data(df)
-        assert "Close" in df.columns
+        result = runner._validate_data(df)
+        assert "Close" in result.columns
 
     def test_truly_missing_column_raises(self, sample_ohlcv_data):
         """Columns that don't exist at all (even case-insensitively)
@@ -1084,6 +1124,35 @@ class TestConverterDeduplication:
         # Best overall is RSI w=14 (ic=0.08)
         assert {"RSI": {"window": 14}} in cfg
 
+    def test_p_value_metric_sorts_ascending(self, sample_ohlcv_data):
+        """P-value metrics should rank lower values first."""
+        from quantrl_lab.alpha_research.converters import results_to_pipeline_config
+
+        equity = pd.Series(np.ones(10), index=pd.date_range("2023-01-01", periods=10))
+        high_p = AlphaResult(
+            job=AlphaJob(
+                data=sample_ohlcv_data,
+                indicator_name="SMA",
+                strategy_name="trend_following",
+                indicator_params={"window": 20},
+            ),
+            metrics={"ic_p_value": 0.20},
+            equity_curve=equity,
+        )
+        low_p = AlphaResult(
+            job=AlphaJob(
+                data=sample_ohlcv_data,
+                indicator_name="EMA",
+                strategy_name="trend_following",
+                indicator_params={"window": 12},
+            ),
+            metrics={"ic_p_value": 0.01},
+            equity_curve=equity,
+        )
+
+        cfg = results_to_pipeline_config([high_p, low_p], top_n=1, metric="ic_p_value", deduplicate=False)
+        assert cfg == [{"EMA": {"window": 12}}]
+
 
 class TestParameterSensitivityRouting:
     """Tests for the explicit indicator_param_grid / strategy_param_grid
@@ -1152,24 +1221,17 @@ class TestParameterSensitivityRouting:
 class TestAlphaSelectorDefaults:
     """Tests for AlphaSelector default candidate coverage."""
 
-    def test_default_candidates_cover_all_strategies(self, sample_ohlcv_data):
-        """Every registered strategy should have at least one default
-        candidate."""
-        from quantrl_lab.alpha_research.registry import VectorizedStrategyRegistry
+    def test_default_candidates_cover_all_research_supported_indicators(self, sample_ohlcv_data):
+        """Every research-supported indicator should appear in the
+        default feature sweep."""
         from quantrl_lab.alpha_research.selector import AlphaSelector
 
         sel = AlphaSelector(data=sample_ohlcv_data, verbose=False)
-        candidates = sel._get_default_candidates()
+        candidates = sel._get_default_candidates(selection_mode="feature")
+        candidate_names = {c["name"] for c in candidates}
 
-        # Every registered strategy should be reachable via some indicator
-        registered = set(VectorizedStrategyRegistry.list_strategies())
-        for strategy_name in registered:
-            mapped = any(
-                sel._map_indicator_to_strategy(c) is not None
-                and sel._map_indicator_to_strategy(c)["name"] == strategy_name
-                for c in candidates
-            )
-            assert mapped, f"No default candidate maps to strategy '{strategy_name}'"
+        for indicator_name in INDICATOR_RESEARCH_METADATA:
+            assert indicator_name in candidate_names
 
     def test_ema_is_in_default_candidates(self, sample_ohlcv_data):
         """EMA was missing before the fix — verify it is now
@@ -1177,7 +1239,7 @@ class TestAlphaSelectorDefaults:
         from quantrl_lab.alpha_research.selector import AlphaSelector
 
         sel = AlphaSelector(data=sample_ohlcv_data, verbose=False)
-        candidates = sel._get_default_candidates()
+        candidates = sel._get_default_candidates(selection_mode="feature")
         names = {c["name"] for c in candidates}
         assert "EMA" in names
 
@@ -1186,9 +1248,47 @@ class TestAlphaSelectorDefaults:
         from quantrl_lab.alpha_research.selector import AlphaSelector
 
         sel = AlphaSelector(data=sample_ohlcv_data, verbose=False)
-        result = sel._map_indicator_to_strategy({"name": "EMA"})
+        result = sel._get_strategy_config({"name": "EMA"}, selection_mode="feature")
         assert result is not None
         assert result["name"] == "trend_following"
+
+    def test_feature_mode_rejects_strategy_only_metric(self, sample_ohlcv_data):
+        """Feature-mode selector should reject backtest-only metrics
+        such as Sharpe."""
+        from quantrl_lab.alpha_research.selector import AlphaSelector
+
+        sel = AlphaSelector(data=sample_ohlcv_data, verbose=False)
+        with pytest.raises(ValueError, match="selection_mode='feature'"):
+            sel.suggest_indicators(metric="sharpe_ratio", top_k=1, selection_mode="feature")
+
+    def test_p_value_metric_uses_max_threshold_and_ascending_rank(self, monkeypatch, sample_ohlcv_data):
+        """Selector should treat p-values as lower-is-better metrics."""
+        from quantrl_lab.alpha_research.selector import AlphaSelector
+
+        sel = AlphaSelector(data=sample_ohlcv_data, verbose=False)
+
+        def fake_run_batch(jobs, n_jobs=1):
+            metric_values = {"SMA": 0.20, "EMA": 0.01, "RSI": 0.03}
+            return [
+                AlphaResult(job=job, metrics={"ic_p_value": metric_values[job.indicator_name]}, status="completed")
+                for job in jobs
+            ]
+
+        monkeypatch.setattr(sel.runner, "run_batch", fake_run_batch)
+
+        selected = sel.suggest_indicators(
+            candidates=[
+                {"name": "SMA", "params": {"window": 20}},
+                {"name": "EMA", "params": {"window": 12}},
+                {"name": "RSI", "params": {"window": 14}},
+            ],
+            metric="ic_p_value",
+            threshold=0.05,
+            top_k=2,
+            selection_mode="feature",
+        )
+
+        assert selected == [{"EMA": {"window": 12}}, {"RSI": {"window": 14}}]
 
 
 # ===========================================================================
@@ -1357,3 +1457,261 @@ class TestMACDCrossoverStrategySignals:
         strategy = MACDCrossoverStrategy(fast_col="EMA_12", slow_col="EMA_26")
         signals = strategy.generate_signals(df)
         assert (signals == SignalType.HOLD.value).all()
+
+
+class TestRegistryDedupGuard:
+    """A-5: re-registering a strategy name warns instead of silently overwriting."""
+
+    def test_reregister_warns(self):
+        import warnings
+
+        from quantrl_lab.alpha_research.base import VectorizedTradingStrategy
+        from quantrl_lab.alpha_research.registry import VectorizedStrategyRegistry
+
+        # Register a dummy strategy
+        @VectorizedStrategyRegistry.register("_test_dedup_strategy")
+        class _DummyA(VectorizedTradingStrategy):
+            def generate_signals(self, data):
+                return pd.Series(0, index=data.index)
+
+            def get_required_columns(self):
+                return []
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            @VectorizedStrategyRegistry.register("_test_dedup_strategy")
+            class _DummyB(VectorizedTradingStrategy):
+                def generate_signals(self, data):
+                    return pd.Series(0, index=data.index)
+
+                def get_required_columns(self):
+                    return []
+
+            assert len(w) == 1
+            assert "_test_dedup_strategy" in str(w[0].message)
+
+        # Cleanup
+        del VectorizedStrategyRegistry._strategies["_test_dedup_strategy"]
+
+
+class TestAlphaJobValidation:
+    """A-6: AlphaJob validates non-empty indicator_name and strategy_name."""
+
+    def test_empty_indicator_name_raises(self, sample_ohlcv_data):
+        with pytest.raises(ValueError, match="indicator_name"):
+            AlphaJob(data=sample_ohlcv_data, indicator_name="", strategy_name="mean_reversion")
+
+    def test_empty_strategy_name_raises(self, sample_ohlcv_data):
+        with pytest.raises(ValueError, match="strategy_name"):
+            AlphaJob(data=sample_ohlcv_data, indicator_name="RSI", strategy_name="")
+
+    def test_whitespace_indicator_name_raises(self, sample_ohlcv_data):
+        with pytest.raises(ValueError, match="indicator_name"):
+            AlphaJob(data=sample_ohlcv_data, indicator_name="  ", strategy_name="mean_reversion")
+
+
+class TestICConstantColumns:
+    """A-8: IC returns 0 for constant signal or returns instead of NaN."""
+
+    def test_constant_signal_returns_zero(self):
+        from quantrl_lab.alpha_research.metrics import calculate_pearson_ic, calculate_rank_ic
+
+        sig = pd.Series([1.0] * 10)  # constant
+        ret = pd.Series(np.random.randn(10))
+        ic, p = calculate_pearson_ic(sig, ret)
+        assert ic == 0.0
+        assert p == 1.0
+        ric, rp = calculate_rank_ic(sig, ret)
+        assert ric == 0.0
+
+    def test_constant_returns_returns_zero(self):
+        from quantrl_lab.alpha_research.metrics import calculate_pearson_ic
+
+        sig = pd.Series(np.random.randn(10))
+        ret = pd.Series([0.01] * 10)  # constant
+        ic, p = calculate_pearson_ic(sig, ret)
+        assert ic == 0.0
+
+
+class TestUnknownIndicatorWarning:
+    """D-8: TechnicalFeatureGenerator warns on unknown indicators."""
+
+    def test_unknown_indicator_warns(self, sample_ohlcv_data):
+        import warnings
+
+        from quantrl_lab.data.processing.features.technical import TechnicalFeatureGenerator
+
+        gen = TechnicalFeatureGenerator(["NONEXISTENT_XYZ"])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = gen.generate(sample_ohlcv_data)
+            assert any("NONEXISTENT_XYZ" in str(warning.message) for warning in w)
+        # Data should be returned unchanged (no crash)
+        assert list(result.columns) == list(sample_ohlcv_data.columns)
+
+
+class TestProcessingModuleExports:
+    """D-12: processing __init__ exports DataPipeline and ProcessingMetadata."""
+
+    def test_data_pipeline_importable(self):
+        from quantrl_lab.data.processing import DataPipeline
+
+        assert DataPipeline is not None
+
+    def test_processing_metadata_importable(self):
+        from quantrl_lab.data.processing import ProcessingMetadata
+
+        assert ProcessingMetadata is not None
+
+
+class TestStrategyMetadata:
+    """A-7: StrategyMetadata and VectorizedStrategyRegistry.get_metadata()."""
+
+    def test_get_metadata_returns_strategy_metadata(self):
+        """get_metadata() returns a StrategyMetadata object with correct
+        fields."""
+        from quantrl_lab.alpha_research.registry import StrategyMetadata, VectorizedStrategyRegistry
+
+        meta = VectorizedStrategyRegistry.get_metadata("mean_reversion")
+        assert isinstance(meta, StrategyMetadata)
+        assert meta.name == "mean_reversion"
+        assert meta.strategy_class is not None
+        assert isinstance(meta.description, str)
+        assert len(meta.description) > 0
+
+    def test_get_metadata_unknown_strategy_raises(self):
+        """get_metadata() raises ValueError for an unknown strategy
+        name."""
+        from quantrl_lab.alpha_research.registry import VectorizedStrategyRegistry
+
+        with pytest.raises(ValueError, match="Unknown strategy"):
+            VectorizedStrategyRegistry.get_metadata("nonexistent_xyz")
+
+    def test_all_registered_strategies_have_descriptions(self):
+        """Every registered strategy should have a non-empty
+        description."""
+        from quantrl_lab.alpha_research.registry import VectorizedStrategyRegistry
+
+        for name in VectorizedStrategyRegistry.list_strategies():
+            meta = VectorizedStrategyRegistry.get_metadata(name)
+            assert meta.description, f"Strategy '{name}' is missing a description"
+
+    def test_metadata_strategy_class_is_instantiable(self):
+        """strategy_class stored in metadata can be used to create an
+        instance."""
+        from quantrl_lab.alpha_research.registry import VectorizedStrategyRegistry
+
+        meta = VectorizedStrategyRegistry.get_metadata("trend_following")
+        strategy = meta.strategy_class(indicator_col="SMA_20")
+        assert strategy is not None
+
+
+class TestValidateColumns:
+    """A-2: VectorizedTradingStrategy.validate_columns() catches broken column wiring."""
+
+    def test_validate_columns_returns_empty_when_all_present(self):
+        """validate_columns returns [] when all required columns
+        exist."""
+        from quantrl_lab.alpha_research.alpha_strategies import TrendFollowingStrategy
+
+        strategy = TrendFollowingStrategy(indicator_col="SMA_20")
+        dates = pd.date_range("2023-01-01", periods=3, freq="B")
+        df = pd.DataFrame({"Close": [100, 101, 102], "SMA_20": [98, 99, 100]}, index=dates)
+        assert strategy.validate_columns(df) == []
+
+    def test_validate_columns_returns_missing_names(self):
+        """validate_columns returns the names of columns not in the
+        DataFrame."""
+        from quantrl_lab.alpha_research.alpha_strategies import TrendFollowingStrategy
+
+        strategy = TrendFollowingStrategy(indicator_col="SMA_20")
+        dates = pd.date_range("2023-01-01", periods=3, freq="B")
+        df = pd.DataFrame({"Close": [100, 101, 102]}, index=dates)  # SMA_20 missing
+        missing = strategy.validate_columns(df)
+        assert "SMA_20" in missing
+
+    def test_validate_columns_multi_col_strategy(self):
+        """MACDCrossoverStrategy.validate_columns catches missing
+        fast/slow cols."""
+        from quantrl_lab.alpha_research.alpha_strategies import MACDCrossoverStrategy
+
+        strategy = MACDCrossoverStrategy(fast_col="MACD_line_12_26", slow_col="MACD_signal_9")
+        dates = pd.date_range("2023-01-01", periods=3, freq="B")
+        df = pd.DataFrame({"Close": [100, 101, 102]}, index=dates)
+        missing = strategy.validate_columns(df)
+        assert "MACD_line_12_26" in missing
+        assert "MACD_signal_9" in missing
+
+    def test_runner_warns_on_missing_columns(self, sample_ohlcv_data):
+        """AlphaRunner.run_job warns (via console) when resolved columns
+        are absent."""
+        # Use ADX with a deliberately wrong strategy that has no auto-wiring
+        # so the resolved indicator_col will be None-free but still missing.
+        # Easiest: provide a strategy_params with a column that won't be created.
+        job = AlphaJob(
+            data=sample_ohlcv_data,
+            indicator_name="SMA",
+            strategy_name="trend_following",
+            strategy_params={"indicator_col": "NONEXISTENT_COL"},
+        )
+        runner = AlphaRunner(verbose=False)
+        result = runner.run_job(job)
+        # Job still completes (defaults to HOLD signals) but result is "completed"
+        assert result.status == "completed"
+
+
+class TestIndicatorStrategyMap:
+    """D-1: INDICATOR_STRATEGY_MAP lives in alpha_strategies, not IndicatorMetadata."""
+
+    def test_map_is_importable_from_alpha_strategies(self):
+        """INDICATOR_STRATEGY_MAP should be importable directly."""
+        from quantrl_lab.alpha_research.alpha_strategies import INDICATOR_STRATEGY_MAP
+
+        assert isinstance(INDICATOR_STRATEGY_MAP, dict)
+        assert len(INDICATOR_STRATEGY_MAP) > 0
+        assert set(INDICATOR_STRATEGY_MAP) == set(INDICATOR_RESEARCH_METADATA)
+
+    def test_all_map_entries_have_name_and_params(self):
+        """Every entry in INDICATOR_STRATEGY_MAP has 'name' and 'params'
+        keys."""
+        from quantrl_lab.alpha_research.alpha_strategies import INDICATOR_STRATEGY_MAP
+
+        for indicator, config in INDICATOR_STRATEGY_MAP.items():
+            assert "name" in config, f"{indicator} entry missing 'name'"
+            assert "params" in config, f"{indicator} entry missing 'params'"
+
+    def test_all_map_strategy_names_are_registered(self):
+        """Every strategy name in INDICATOR_STRATEGY_MAP must be
+        registered."""
+        from quantrl_lab.alpha_research.alpha_strategies import INDICATOR_STRATEGY_MAP
+        from quantrl_lab.alpha_research.registry import VectorizedStrategyRegistry
+
+        registered = set(VectorizedStrategyRegistry.list_strategies())
+        for indicator, config in INDICATOR_STRATEGY_MAP.items():
+            strategy_name = config["name"]
+            assert (
+                strategy_name in registered
+            ), f"INDICATOR_STRATEGY_MAP['{indicator}'] points to unregistered strategy '{strategy_name}'"
+
+    def test_indicator_metadata_has_no_strategy_fields(self):
+        """D-1: IndicatorMetadata must NOT have strategy_name or strategy_params fields."""
+        from quantrl_lab.data.indicators.registry import IndicatorMetadata
+
+        meta = IndicatorMetadata.__dataclass_fields__
+        assert "strategy_name" not in meta, "strategy_name should have been removed from IndicatorMetadata (D-1)"
+        assert "strategy_params" not in meta, "strategy_params should have been removed from IndicatorMetadata (D-1)"
+
+    def test_adx_maps_to_adx_trend_strategy(self):
+        """ADX indicator should map to the adx_trend strategy (A-1
+        fix)."""
+        from quantrl_lab.alpha_research.alpha_strategies import INDICATOR_STRATEGY_MAP
+
+        assert INDICATOR_STRATEGY_MAP["ADX"]["name"] == "adx_trend"
+
+    def test_all_registered_indicators_have_research_metadata(self):
+        """The research registry should stay in lockstep with
+        IndicatorRegistry."""
+        from quantrl_lab.data.indicators import IndicatorRegistry
+
+        assert set(IndicatorRegistry.list_all()) == set(INDICATOR_RESEARCH_METADATA)

--- a/tests/alpha_research/test_integration.py
+++ b/tests/alpha_research/test_integration.py
@@ -1,0 +1,116 @@
+"""Tests for alpha_research → data.processing integration helpers."""
+
+import pandas as pd
+import pytest
+
+from quantrl_lab.alpha_research import (
+    AlphaSelectionConfig,
+    build_processing_config_from_alpha_selection,
+    select_indicators_for_processing,
+)
+from quantrl_lab.data.processing import ProcessingPipelineConfig, SplitConfig
+
+
+@pytest.fixture
+def sample_single_symbol_data() -> pd.DataFrame:
+    """Create simple single-symbol OHLCV data."""
+    dates = pd.date_range("2020-01-01", periods=12, freq="D")
+    return pd.DataFrame(
+        {
+            "Date": dates,
+            "Open": range(12),
+            "High": range(100, 112),
+            "Low": range(10, 22),
+            "Close": range(50, 62),
+            "Volume": range(1000, 1012),
+            "Symbol": ["AAPL"] * 12,
+        }
+    )
+
+
+def test_select_indicators_for_processing_uses_train_split_only(monkeypatch, sample_single_symbol_data):
+    """Alpha-selection helper should operate on the raw training split
+    only."""
+    captured = {}
+
+    def fake_suggest_indicators(self, candidates=None, metric="ic", threshold=0.0, top_k=5, selection_mode="feature"):
+        captured["rows"] = len(self.data)
+        captured["start"] = pd.to_datetime(self.data["Date"]).min()
+        captured["end"] = pd.to_datetime(self.data["Date"]).max()
+        captured["selection_mode"] = selection_mode
+        return [{"SMA": {"window": 3}}]
+
+    monkeypatch.setattr(
+        "quantrl_lab.alpha_research.selector.AlphaSelector.suggest_indicators",
+        fake_suggest_indicators,
+    )
+
+    indicators, metadata = select_indicators_for_processing(
+        sample_single_symbol_data,
+        AlphaSelectionConfig(metric="ic", threshold=0.0, top_k=1),
+        split_config=SplitConfig(splits={"train": ("2020-01-01", "2020-01-06"), "test": ("2020-01-07", "2020-01-12")}),
+    )
+
+    assert indicators == [{"SMA": {"window": 3}}]
+    assert captured["rows"] == 6
+    assert captured["start"] == pd.Timestamp("2020-01-01")
+    assert captured["end"] == pd.Timestamp("2020-01-06")
+    assert captured["selection_mode"] == "feature"
+    assert metadata["selected_from_split"] == "train"
+
+
+def test_build_processing_config_from_alpha_selection_populates_pipeline(monkeypatch, sample_single_symbol_data):
+    """Adapter should return a ready-to-run processing config with
+    selected indicators."""
+
+    def fake_suggest_indicators(self, candidates=None, metric="ic", threshold=0.0, top_k=5, selection_mode="feature"):
+        return [{"RSI": {"window": 14}}]
+
+    monkeypatch.setattr(
+        "quantrl_lab.alpha_research.selector.AlphaSelector.suggest_indicators",
+        fake_suggest_indicators,
+    )
+
+    processing_config, metadata = build_processing_config_from_alpha_selection(
+        sample_single_symbol_data,
+        {"metric": "ic", "threshold": 0.0, "top_k": 1},
+        split_config={"train": 0.7, "test": 0.3},
+        processing_config=ProcessingPipelineConfig(verbose=True),
+    )
+
+    assert processing_config.indicators == [{"RSI": {"window": 14}}]
+    assert processing_config.split == SplitConfig(splits={"train": 0.7, "test": 0.3})
+    assert processing_config.verbose is True
+    assert metadata["selection_mode"] == "feature"
+    assert metadata["selected_from_split"] == "train"
+
+
+def test_build_processing_config_rejects_existing_indicators(sample_single_symbol_data):
+    """Existing manual indicators should not be mixed implicitly with
+    alpha-selected ones."""
+    with pytest.raises(ValueError, match="indicators must be None"):
+        build_processing_config_from_alpha_selection(
+            sample_single_symbol_data,
+            {"metric": "ic"},
+            processing_config=ProcessingPipelineConfig(indicators=["SMA"]),
+        )
+
+
+def test_select_indicators_for_processing_rejects_multi_symbol_input():
+    """Single-series helper should direct panel workflows to
+    suggest_for_universe."""
+    dates = pd.date_range("2020-01-01", periods=4, freq="D")
+    df = pd.DataFrame(
+        {
+            "Date": list(dates) * 2,
+            "Open": list(range(4)) + list(range(10, 14)),
+            "High": list(range(100, 104)) + list(range(110, 114)),
+            "Low": list(range(10, 14)) + list(range(20, 24)),
+            "Close": list(range(50, 54)) + list(range(60, 64)),
+            "Volume": [1000] * 8,
+            "Symbol": ["AAPL"] * 4 + ["MSFT"] * 4,
+        }
+    )
+
+    with pytest.raises(ValueError, match="suggest_for_universe"):
+        select_indicators_for_processing(df, {"metric": "ic"}, split_config={"train": 0.5, "test": 0.5})

--- a/tests/data/processing/features/test_cross_sectional.py
+++ b/tests/data/processing/features/test_cross_sectional.py
@@ -125,3 +125,23 @@ def test_metadata_updated(panel_df, metadata):
     step = CrossSectionalStep(columns=["RSI_14"], methods=["zscore"])
     step.process(panel_df, metadata)
     assert "RSI_14_cs_zscore" in metadata.cross_sectional_features
+
+
+def test_date_column_supported_without_datetime_index(metadata):
+    """Cross-sectional step should work with a date column instead of
+    datetime index."""
+    dates = pd.date_range("2023-01-01", periods=2, freq="D")
+    df = pd.DataFrame(
+        {
+            "Date": [dates[0], dates[0], dates[1], dates[1]],
+            "Symbol": ["AAPL", "MSFT", "AAPL", "MSFT"],
+            "RSI_14": [40.0, 60.0, 30.0, 70.0],
+        }
+    )
+
+    step = CrossSectionalStep(columns=["RSI_14"], methods=["zscore"], date_column="Date")
+    result = step.process(df, metadata)
+
+    assert "RSI_14_cs_zscore" in result.columns
+    for _, group in result.groupby("Date"):
+        assert abs(group["RSI_14_cs_zscore"].mean()) < 1e-6

--- a/tests/data/processing/features/test_technical.py
+++ b/tests/data/processing/features/test_technical.py
@@ -113,6 +113,13 @@ class TestTechnicalFeatureGeneratorGenerate:
         assert "SMA_20" in result.columns
         # No error raised
 
+    def test_generate_strict_mode_raises_on_unknown_indicator(self, sample_ohlcv_data):
+        """Strict mode should fail fast on unknown indicators."""
+        generator = TechnicalFeatureGenerator(["UNKNOWN_INDICATOR", "SMA"], strict=True)
+
+        with pytest.raises(ValueError, match="UNKNOWN_INDICATOR"):
+            generator.generate(sample_ohlcv_data)
+
 
 class TestTechnicalFeatureGeneratorMetadata:
     """Test TechnicalFeatureGenerator.get_metadata() method."""

--- a/tests/data/processing/test_pipeline.py
+++ b/tests/data/processing/test_pipeline.py
@@ -1,0 +1,136 @@
+"""Tests for high-level pipeline assembly and config objects."""
+
+import pandas as pd
+import pytest
+
+from quantrl_lab.data.processing import (
+    CleanupConfig,
+    CrossSectionalConfig,
+    DataPipeline,
+    DataProcessor,
+    ProcessingPipelineConfig,
+    SplitConfig,
+)
+from quantrl_lab.data.processing.steps import ColumnCleanupStep, NumericConversionStep
+
+
+@pytest.fixture
+def panel_ohlcv_data() -> pd.DataFrame:
+    """Create a small multi-symbol panel dataset with a Date column."""
+    dates = pd.date_range("2024-01-01", periods=5, freq="D")
+    rows = []
+    for date in dates:
+        rows.append(
+            {
+                "Date": date,
+                "Symbol": "AAPL",
+                "Open": 100.0,
+                "High": 105.0,
+                "Low": 99.0,
+                "Close": 102.0,
+                "Volume": 1_000_000,
+            }
+        )
+        rows.append(
+            {
+                "Date": date,
+                "Symbol": "MSFT",
+                "Open": 200.0,
+                "High": 210.0,
+                "Low": 198.0,
+                "Close": 205.0,
+                "Volume": 1_500_000,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def test_data_pipeline_exposes_step_names_and_description():
+    """DataPipeline should provide lightweight introspection for
+    assembled steps."""
+    pipeline = DataPipeline().add_step(NumericConversionStep()).add_step(ColumnCleanupStep())
+
+    assert pipeline.get_step_names() == ["Numeric Conversion", "Column Cleanup"]
+    assert pipeline.describe() == {
+        "step_count": 2,
+        "steps": [
+            {"index": 1, "name": "Numeric Conversion", "type": "NumericConversionStep"},
+            {"index": 2, "name": "Column Cleanup", "type": "ColumnCleanupStep"},
+        ],
+    }
+
+
+def test_build_pipeline_accepts_typed_pipeline_config(panel_ohlcv_data):
+    """DataProcessor.build_pipeline should assemble a debuggable
+    pipeline from config objects."""
+    processor = DataProcessor(panel_ohlcv_data)
+    pipeline = processor.build_pipeline(
+        pipeline_config=ProcessingPipelineConfig(
+            indicators=[{"SMA": {"window": 2}}],
+            cross_sectional=CrossSectionalConfig(columns=["Close"], methods=["rank"]),
+            split=SplitConfig(splits={"train": 0.6, "test": 0.4}),
+        )
+    )
+
+    assert pipeline.get_step_names() == [
+        "Technical Indicators",
+        "Numeric Conversion",
+        "Cross-Sectional Features",
+        "Column Cleanup",
+    ]
+    assert pipeline.describe()["step_count"] == 4
+
+
+def test_data_processing_pipeline_accepts_typed_pipeline_config(panel_ohlcv_data):
+    """Typed config should flow through execution and preserve panel
+    identity."""
+    processor = DataProcessor(panel_ohlcv_data)
+    result, metadata = processor.data_processing_pipeline(
+        pipeline_config=ProcessingPipelineConfig(
+            cross_sectional=CrossSectionalConfig(columns=["Close"], methods=["zscore", "rank"]),
+            cleanup=CleanupConfig(),
+        )
+    )
+
+    assert "Close_cs_zscore" in result.columns
+    assert "Close_cs_rank" in result.columns
+    assert "Symbol" in result.columns
+    assert "Date" not in result.columns
+    assert metadata["cross_sectional_features"] == ["Close_cs_zscore", "Close_cs_rank"]
+
+
+def test_data_processing_pipeline_exposes_cross_sectional_args(panel_ohlcv_data):
+    """Cross-sectional config should be usable without constructing the
+    full pipeline config."""
+    processor = DataProcessor(panel_ohlcv_data)
+    result, metadata = processor.data_processing_pipeline(
+        cross_sectional_config={"columns": ["Close"], "methods": ["rank"]},
+    )
+
+    assert "Close_cs_rank" in result.columns
+    assert "Symbol" in result.columns
+    assert metadata["cross_sectional_features"] == ["Close_cs_rank"]
+
+
+def test_build_pipeline_rejects_mixed_pipeline_styles(panel_ohlcv_data):
+    """Users should pick either explicit args or a pipeline config
+    object."""
+    processor = DataProcessor(panel_ohlcv_data)
+
+    with pytest.raises(ValueError, match="Use either pipeline_config or individual pipeline arguments"):
+        processor.build_pipeline(
+            indicators=["SMA"],
+            pipeline_config=ProcessingPipelineConfig(indicators=["RSI"]),
+        )
+
+
+def test_legacy_cleanup_kwargs_still_work_with_warning(panel_ohlcv_data):
+    """Legacy kwargs should remain backward compatible while steering
+    users to the typed config API."""
+    processor = DataProcessor(panel_ohlcv_data)
+
+    with pytest.warns(FutureWarning, match="cleanup_config"):
+        result, _ = processor.data_processing_pipeline(columns_to_drop=["Date", "Symbol"])
+
+    assert "Date" not in result.columns
+    assert "Symbol" not in result.columns

--- a/tests/data/test_processor_alpha_selection.py
+++ b/tests/data/test_processor_alpha_selection.py
@@ -1,0 +1,35 @@
+"""Tests for deprecated alpha-selection usage on DataProcessor."""
+
+import pandas as pd
+import pytest
+
+from quantrl_lab.data.processing import DataProcessor
+
+
+@pytest.fixture
+def sample_single_symbol_data() -> pd.DataFrame:
+    """Create simple single-symbol OHLCV data."""
+    dates = pd.date_range("2020-01-01", periods=12, freq="D")
+    return pd.DataFrame(
+        {
+            "Date": dates,
+            "Open": range(12),
+            "High": range(100, 112),
+            "Low": range(10, 22),
+            "Close": range(50, 62),
+            "Volume": range(1000, 1012),
+            "Symbol": ["AAPL"] * 12,
+        }
+    )
+
+
+def test_data_processor_rejects_alpha_selection_shortcut(sample_single_symbol_data):
+    """DataProcessor should no longer run alpha selection internally."""
+    processor = DataProcessor(sample_single_symbol_data)
+
+    with pytest.warns(FutureWarning, match="build_processing_config_from_alpha_selection"):
+        with pytest.raises(ValueError, match="no longer performs alpha selection"):
+            processor.data_processing_pipeline(
+                alpha_selection_config={"metric": "ic"},
+                split_config={"train": 0.7, "test": 0.3},
+            )

--- a/tests/data/test_processor_integration.py
+++ b/tests/data/test_processor_integration.py
@@ -157,6 +157,64 @@ class TestDataProcessorSplitting:
         assert train_last < val_first
         assert val_last < test_first
 
+    def test_panel_split_preserves_symbol_by_default(self):
+        """Multi-symbol split outputs should retain Symbol by
+        default."""
+        dates = pd.date_range("2020-01-01", periods=6, freq="D")
+        df = pd.DataFrame(
+            {
+                "Date": list(dates) * 2,
+                "Open": list(range(6)) + list(range(10, 16)),
+                "High": list(range(100, 106)) + list(range(110, 116)),
+                "Low": list(range(50, 56)) + list(range(60, 66)),
+                "Close": list(range(70, 76)) + list(range(80, 86)),
+                "Volume": [1000] * 12,
+                "Symbol": ["AAPL"] * 6 + ["MSFT"] * 6,
+            }
+        )
+
+        processor = DataProcessor(df)
+        result, _ = processor.data_processing_pipeline(
+            split_config={
+                "train": ("2020-01-01", "2020-01-03"),
+                "test": ("2020-01-04", "2020-01-06"),
+            }
+        )
+
+        assert "Symbol" in result["train"].columns
+        assert "Symbol" in result["test"].columns
+        assert "Date" not in result["train"].columns
+        assert set(result["train"]["Symbol"]) == {"AAPL", "MSFT"}
+
+    def test_panel_split_honors_explicit_symbol_drop(self):
+        """Explicit cleanup requests should still be honored after
+        split."""
+        dates = pd.date_range("2020-01-01", periods=6, freq="D")
+        df = pd.DataFrame(
+            {
+                "Date": list(dates) * 2,
+                "Open": list(range(6)) + list(range(10, 16)),
+                "High": list(range(100, 106)) + list(range(110, 116)),
+                "Low": list(range(50, 56)) + list(range(60, 66)),
+                "Close": list(range(70, 76)) + list(range(80, 86)),
+                "Volume": [1000] * 12,
+                "Symbol": ["AAPL"] * 6 + ["MSFT"] * 6,
+            }
+        )
+
+        processor = DataProcessor(df)
+        result, _ = processor.data_processing_pipeline(
+            split_config={
+                "train": ("2020-01-01", "2020-01-03"),
+                "test": ("2020-01-04", "2020-01-06"),
+            },
+            cleanup_config={"columns_to_drop": ["Date", "Symbol"]},
+        )
+
+        assert "Symbol" not in result["train"].columns
+        assert "Symbol" not in result["test"].columns
+        assert "Date" not in result["train"].columns
+
 
 class TestDataProcessorDirectSplitterUsage:
     """Test using splitters directly (new API)."""
@@ -300,3 +358,78 @@ class TestDataProcessorCleanup:
             {"CMF": {"window": 10}},
             {"SUPERTREND": {"window": 10, "multiplier": 3.0}},
         ]
+
+    def test_indicator_metadata_tracks_requested_applied_and_skipped(self):
+        """Metadata should capture requested, applied, and skipped
+        indicators."""
+        dates = pd.date_range("2020-01-01", periods=20, freq="D")
+        df = pd.DataFrame(
+            {
+                "Date": dates,
+                "Open": range(20),
+                "High": [x + 5 for x in range(20)],
+                "Low": [x for x in range(20)],
+                "Close": [x + 2 for x in range(20)],
+                "Volume": [1000 + x for x in range(20)],
+            }
+        )
+
+        processor = DataProcessor(df)
+        result, metadata = processor.data_processing_pipeline(indicators=["UNKNOWN_INDICATOR", {"SMA": {"window": 3}}])
+
+        assert "SMA_3" in result.columns
+        assert metadata["requested_technical_indicators"] == ["UNKNOWN_INDICATOR", {"SMA": {"window": 3}}]
+        assert metadata["applied_technical_indicators"] == [{"SMA": {"window": 3}}]
+        assert metadata["failed_technical_indicators"] == []
+        assert metadata["skipped_technical_indicators"] == [
+            {
+                "indicator": "UNKNOWN_INDICATOR",
+                "config": "UNKNOWN_INDICATOR",
+                "reason": "not registered in IndicatorRegistry",
+            }
+        ]
+        assert metadata["strict_indicators"] is False
+
+    def test_indicator_metadata_tracks_failures(self):
+        """Metadata should capture failed indicators without hiding
+        later successes."""
+        dates = pd.date_range("2020-01-01", periods=20, freq="D")
+        df = pd.DataFrame(
+            {
+                "Date": dates,
+                "Open": range(20),
+                "High": [x + 5 for x in range(20)],
+                "Low": [x for x in range(20)],
+                "Close": [x + 2 for x in range(20)],
+                "Volume": [1000 + x for x in range(20)],
+            }
+        )
+
+        processor = DataProcessor(df)
+        result, metadata = processor.data_processing_pipeline(indicators=[{"SMA": {"window": "bad"}}, "RSI"])
+
+        assert "RSI_14" in result.columns
+        assert metadata["applied_technical_indicators"] == ["RSI"]
+        assert metadata["skipped_technical_indicators"] == []
+        assert metadata["failed_technical_indicators"][0]["indicator"] == "SMA"
+        assert metadata["failed_technical_indicators"][0]["config"] == {"SMA": {"window": "bad"}}
+        assert "window must be an integer" in metadata["failed_technical_indicators"][0]["error"]
+
+    def test_strict_indicators_fail_fast(self):
+        """Strict mode should reject unknown indicators."""
+        dates = pd.date_range("2020-01-01", periods=20, freq="D")
+        df = pd.DataFrame(
+            {
+                "Date": dates,
+                "Open": range(20),
+                "High": [x + 5 for x in range(20)],
+                "Low": [x for x in range(20)],
+                "Close": [x + 2 for x in range(20)],
+                "Volume": [1000 + x for x in range(20)],
+            }
+        )
+
+        processor = DataProcessor(df)
+
+        with pytest.raises(ValueError, match="UNKNOWN_INDICATOR"):
+            processor.data_processing_pipeline(indicators=["UNKNOWN_INDICATOR"], strict_indicators=True)


### PR DESCRIPTION
## Summary

  This PR cleans up the `data.processing` pipeline, removes the embedded `data -> alpha_research` coupling, and makes the
  downstream feature-selection flow more explicit and safer.

  The main goals were:
  - make pipeline assembly more intuitive
  - fix leakage / panel-data safety issues in alpha-selection integration
  - improve downstream feature-contract visibility
  - align examples, docs, and notebooks with the current API

  ## What changed

  ### Processing pipeline
  - added typed pipeline config objects for processing, cleanup, splitting, cross-sectional features, and alpha-selection-
  related workflows
  - added `DataProcessor.build_pipeline(...)` for explicit pipeline assembly
  - added `DataPipeline.describe()` / `get_step_names()` for inspection and debugging
  - exposed cross-sectional processing through the high-level API
  - preserved `Symbol` correctly in split/panel workflows
  - stopped hard-resetting cleanup behavior after split
  - added stricter technical-indicator handling and richer metadata for requested/applied/skipped/failed indicators

  ### Alpha research integration
  - removed in-pipeline alpha selection from `DataProcessor`
  - introduced an explicit integration adapter under `alpha_research`
  - made selection train-split aware and prevented unsafe multi-symbol usage in the convenience path
  - separated `feature` vs `strategy` selection modes
  - added explicit indicator research metadata and broader indicator coverage for alpha selection
  - fixed p-value metric ranking/filtering so lower p-values are treated as better

  ### Docs / examples
  - updated processing and alpha-research docs
  - added a package README for `src/quantrl_lab/data`
  - updated the relevant examples to use the explicit integration/config flow
  - updated `notebooks/data_joining_tutorial.ipynb` to use the typed pipeline config API

  ## Why

  Before this PR:
  - alpha selection inside `DataProcessor` could leak future information
  - the convenience path was unsafe for panel data
  - key pipeline controls were hidden behind loosely typed kwargs
  - split-mode cleanup could degrade downstream multi-asset workflows
  - the alpha/data contract had drifted, especially after indicator expansion

  This PR makes the behavior more explicit, easier to inspect, and safer for downstream experimentation and training
  workflows.

  ## Validation

  - `uv run pytest tests/data tests/alpha_research -q`
  - `pre-commit run --files <touched files>`
  - updated and ran the relevant processing / alpha-research examples
  - validated the updated notebook structure

  ## Notes

  - `DataProcessor(alpha_selection_config=...)` is no longer the supported path
  - the recommended flow is now:
    1. run alpha selection explicitly through `alpha_research`
    2. inspect/filter selected indicators
    3. pass indicator configs into `DataProcessor`