### PR TITLE
feat(data): add yfinance crypto data fetcher

### DIFF
--- a/src/quantrl_lab/data/__init__.py
+++ b/src/quantrl_lab/data/__init__.py
@@ -1,6 +1,7 @@
 # Data sources
 # Configuration
 from .config import DataConfig, config
+from .crypto import fetch_crypto_data
 
 # Exceptions
 from .exceptions import (

--- a/src/quantrl_lab/data/crypto.py
+++ b/src/quantrl_lab/data/crypto.py
@@ -1,27 +1,26 @@
 import yfinance as yf
 import pandas as pd
-from typing import Optional
 
 def fetch_crypto_data(
-    symbol: str = "BTC-USD", 
-    period: str = "2y", 
+    symbol: str = "BTC-USD",
+    period: str = "2y",
     interval: str = "1d"
 ) -> pd.DataFrame:
     """
-    Fetches historical crypto data from Yahoo Finance and formats it 
+    Fetches historical crypto data from Yahoo Finance and formats it
     specifically for the QuantRL-Lab environment.
-    
+
     Args:
         symbol: The cryptocurrency ticker (e.g., 'BTC-USD', 'ETH-USD').
         period: Data period to download (e.g., '1mo', '1y', 'max').
         interval: Data interval (e.g., '1d', '1h', '15m').
-        
+
     Returns:
         pd.DataFrame: OHLCV dataframe formatted with float32 for RL agents.
     """
     ticker = yf.Ticker(symbol)
     df = ticker.history(period=period, interval=interval)
-    
+
     if df.empty:
         raise ValueError(f"No data found for symbol {symbol}. Check if the ticker is correct.")
 

--- a/src/quantrl_lab/data/crypto.py
+++ b/src/quantrl_lab/data/crypto.py
@@ -1,0 +1,40 @@
+import yfinance as yf
+import pandas as pd
+from typing import Optional
+
+def fetch_crypto_data(
+    symbol: str = "BTC-USD", 
+    period: str = "2y", 
+    interval: str = "1d"
+) -> pd.DataFrame:
+    """
+    Fetches historical crypto data from Yahoo Finance and formats it 
+    specifically for the QuantRL-Lab environment.
+    
+    Args:
+        symbol: The cryptocurrency ticker (e.g., 'BTC-USD', 'ETH-USD').
+        period: Data period to download (e.g., '1mo', '1y', 'max').
+        interval: Data interval (e.g., '1d', '1h', '15m').
+        
+    Returns:
+        pd.DataFrame: OHLCV dataframe formatted with float32 for RL agents.
+    """
+    ticker = yf.Ticker(symbol)
+    df = ticker.history(period=period, interval=interval)
+    
+    if df.empty:
+        raise ValueError(f"No data found for symbol {symbol}. Check if the ticker is correct.")
+
+    # Drop non-price columns that yfinance sometimes injects
+    cols_to_drop = [col for col in ['Dividends', 'Stock Splits'] if col in df.columns]
+    df = df.drop(columns=cols_to_drop)
+
+    # Standardize column names to lowercase (open, high, low, close, volume)
+    df.columns = [col.lower() for col in df.columns]
+
+    # Convert timezone-aware datetimes to timezone-naive to prevent Gymnasium environment crashes
+    if df.index.tz is not None:
+        df.index = df.index.tz_localize(None)
+
+    # Cast to float32 for Neural Network memory efficiency
+    return df.astype("float32")


### PR DESCRIPTION
### Motivation
Following up on the roadmap item to add **Crypto Data Sources**. Since `yfinance` is already in the project dependencies, I utilized it to build a lightweight, native crypto fetcher without bloating the `pyproject.toml`.

### Implementation Details
* Added `fetch_crypto_data()` in `src/quantrl_lab/data/crypto.py`.
* Automatically sanitizes the dataframe by dropping Yahoo's 'Dividends/Stock Splits' columns.
* Standardizes all columns to lowercase (`open, high, low, close, volume`) to match the existing environment expectations.
* Strips timezone data from the index (timezone-aware pandas indices sometimes cause serialization crashes in `gymnasium`).
* Casts the entire matrix to `float32` for neural network memory efficiency.

### Usage Example
```python
from quantrl_lab.data import fetch_crypto_data

# Fetches 2 years of daily Bitcoin data formatted for the RL env
train_df = fetch_crypto_data(symbol="BTC-USD", period="2y", interval="1d")


